### PR TITLE
Refactored Maven-plugin-api class names

### DIFF
--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/Configuration.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/Configuration.java
@@ -27,15 +27,12 @@ import java.util.List;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public interface MavenPluginConfigurationElement extends MavenPluginElement
+public interface Configuration extends PluginElement
 {
-   String getName();
+   boolean hasConfigurationElement(String element);
+   ConfigurationElement getConfigurationElement(String element);
+   List<ConfigurationElement> listConfigurationElements();
+   Configuration addConfigurationElement(ConfigurationElement element);
+   void removeConfigurationElement(String elementName);
 
-   boolean isPlugin();
-
-   boolean hasChilderen();
-
-   String getText();
-
-   List<MavenPluginElement> getChildren();
 }

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/ConfigurationBuilder.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/ConfigurationBuilder.java
@@ -27,12 +27,12 @@ import java.util.List;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public class MavenPluginConfigurationBuilder implements MavenPluginConfiguration
+public class ConfigurationBuilder implements Configuration
 {
-   private MavenPluginConfigurationImpl mavenPluginConfiguration = new MavenPluginConfigurationImpl();
+   private ConfigurationImpl mavenPluginConfiguration = new ConfigurationImpl();
    private MavenPluginBuilder origin;
 
-   @Override public MavenPluginConfigurationElement getConfigurationElement(String element)
+   @Override public ConfigurationElement getConfigurationElement(String element)
    {
       return mavenPluginConfiguration.getConfigurationElement(element);
    }
@@ -42,12 +42,12 @@ public class MavenPluginConfigurationBuilder implements MavenPluginConfiguration
       return mavenPluginConfiguration.hasConfigurationElement(configElement);
    }
 
-   @Override public List<MavenPluginConfigurationElement> listConfigurationElements()
+   @Override public List<ConfigurationElement> listConfigurationElements()
    {
       return mavenPluginConfiguration.listConfigurationElements();
    }
 
-   @Override public MavenPluginConfiguration addConfigurationElement(MavenPluginConfigurationElement element)
+   @Override public Configuration addConfigurationElement(ConfigurationElement element)
    {
       return mavenPluginConfiguration.addConfigurationElement(element);
    }
@@ -62,41 +62,41 @@ public class MavenPluginConfigurationBuilder implements MavenPluginConfiguration
       return mavenPluginConfiguration.toString();
    }
 
-   private MavenPluginConfigurationBuilder() {
+   private ConfigurationBuilder() {
 
    }
 
-   public MavenPluginConfigurationElementBuilder createConfigurationElement(String name)
+   public ConfigurationElementBuilder createConfigurationElement(String name)
    {
-      MavenPluginConfigurationElementBuilder builder = MavenPluginConfigurationElementBuilder.create(this);
+      ConfigurationElementBuilder builder = ConfigurationElementBuilder.create(this);
       builder.setName(name);
       mavenPluginConfiguration.addConfigurationElement(builder);
       return builder;
    }
 
-   private MavenPluginConfigurationBuilder(MavenPluginBuilder pluginBuilder) {
+   private ConfigurationBuilder(MavenPluginBuilder pluginBuilder) {
       origin = pluginBuilder;
    }
 
 
-   private MavenPluginConfigurationBuilder(MavenPluginConfiguration existingConfig, MavenPluginBuilder pluginBuilder) {
+   private ConfigurationBuilder(Configuration existingConfig, MavenPluginBuilder pluginBuilder) {
       origin = pluginBuilder;
-      for (MavenPluginConfigurationElement element : existingConfig.listConfigurationElements())
+      for (ConfigurationElement element : existingConfig.listConfigurationElements())
       {
          mavenPluginConfiguration.addConfigurationElement(element);
       }
    }
 
-   public static MavenPluginConfigurationBuilder create() {
-      return new MavenPluginConfigurationBuilder();
+   public static ConfigurationBuilder create() {
+      return new ConfigurationBuilder();
    }
 
-   public static MavenPluginConfigurationBuilder create(MavenPluginBuilder pluginBuilder) {
-      return new MavenPluginConfigurationBuilder(pluginBuilder);
+   public static ConfigurationBuilder create(MavenPluginBuilder pluginBuilder) {
+      return new ConfigurationBuilder(pluginBuilder);
    }
 
-   public static MavenPluginConfigurationBuilder create(MavenPluginConfiguration existingConfig, MavenPluginBuilder pluginBuilder) {
-      return new MavenPluginConfigurationBuilder(existingConfig, pluginBuilder);
+   public static ConfigurationBuilder create(Configuration existingConfig, MavenPluginBuilder pluginBuilder) {
+      return new ConfigurationBuilder(existingConfig, pluginBuilder);
    }
 
    public MavenPluginBuilder getOrigin()

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/ConfigurationElement.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/ConfigurationElement.java
@@ -27,12 +27,15 @@ import java.util.List;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public interface MavenPluginConfiguration extends MavenPluginElement
+public interface ConfigurationElement extends PluginElement
 {
-   boolean hasConfigurationElement(String element);
-   MavenPluginConfigurationElement getConfigurationElement(String element);
-   List<MavenPluginConfigurationElement> listConfigurationElements();
-   MavenPluginConfiguration addConfigurationElement(MavenPluginConfigurationElement element);
-   void removeConfigurationElement(String elementName);
+   String getName();
 
+   boolean isPlugin();
+
+   boolean hasChilderen();
+
+   String getText();
+
+   List<PluginElement> getChildren();
 }

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/ConfigurationElementBuilder.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/ConfigurationElementBuilder.java
@@ -27,11 +27,11 @@ import java.util.List;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public class MavenPluginConfigurationElementBuilder implements MavenPluginConfigurationElement
+public class ConfigurationElementBuilder implements ConfigurationElement
 {
-   private MavenPluginConfigurationElementImpl configurationElement;
-   private MavenPluginConfigurationBuilder configurationBuilder;
-   private MavenPluginConfigurationElementBuilder elementBuilder;
+   private ConfigurationElementImpl configurationElement;
+   private ConfigurationBuilder configurationBuilder;
+   private ConfigurationElementBuilder elementBuilder;
 
    @Override public String getName()
    {
@@ -53,92 +53,92 @@ public class MavenPluginConfigurationElementBuilder implements MavenPluginConfig
       return configurationElement.getText();
    }
 
-   public MavenPluginConfigurationElementBuilder setText(String text)
+   public ConfigurationElementBuilder setText(String text)
    {
       configurationElement.setText(text);
       return this;
    }
 
-   public MavenPluginConfigurationElementBuilder addChild(String configElement)
+   public ConfigurationElementBuilder addChild(String configElement)
    {
-      MavenPluginConfigurationElementBuilder builder =
-              MavenPluginConfigurationElementBuilder.create(this)
+      ConfigurationElementBuilder builder =
+              ConfigurationElementBuilder.create(this)
                       .setName(configElement);
       configurationElement.addChild(builder);
       return builder;
    }
 
-   public MavenPluginConfigurationElementBuilder addChild(MavenPluginElement element)
+   public ConfigurationElementBuilder addChild(PluginElement element)
    {
       configurationElement.addChild(element);
       return this;
    }
 
 
-   public MavenPluginConfigurationBuilder getParentPluginConfig()
+   public ConfigurationBuilder getParentPluginConfig()
    {
       return configurationBuilder;
    }
 
-   public MavenPluginConfigurationElementBuilder getParentElement()
+   public ConfigurationElementBuilder getParentElement()
    {
       return elementBuilder;
    }
 
-   private MavenPluginConfigurationElementBuilder()
+   private ConfigurationElementBuilder()
    {
-      configurationElement = new MavenPluginConfigurationElementImpl();
+      configurationElement = new ConfigurationElementImpl();
    }
 
-   private MavenPluginConfigurationElementBuilder(MavenPluginConfigurationBuilder configurationBuilder)
+   private ConfigurationElementBuilder(ConfigurationBuilder configurationBuilder)
    {
-      configurationElement = new MavenPluginConfigurationElementImpl();
+      configurationElement = new ConfigurationElementImpl();
       this.configurationBuilder = configurationBuilder;
    }
 
-   private MavenPluginConfigurationElementBuilder(MavenPluginConfigurationElementBuilder elementBuilder)
+   private ConfigurationElementBuilder(ConfigurationElementBuilder elementBuilder)
    {
-      configurationElement = new MavenPluginConfigurationElementImpl();
+      configurationElement = new ConfigurationElementImpl();
       this.elementBuilder = elementBuilder;
    }
 
-   public static MavenPluginConfigurationElementBuilder create()
+   public static ConfigurationElementBuilder create()
    {
-      return new MavenPluginConfigurationElementBuilder();
+      return new ConfigurationElementBuilder();
    }
 
-   public static MavenPluginConfigurationElementBuilder create(MavenPluginConfigurationBuilder configurationBuilder)
+   public static ConfigurationElementBuilder create(ConfigurationBuilder configurationBuilder)
    {
-      MavenPluginConfigurationElementBuilder builder = new MavenPluginConfigurationElementBuilder(configurationBuilder);
+      ConfigurationElementBuilder builder = new ConfigurationElementBuilder(configurationBuilder);
       builder.configurationBuilder = configurationBuilder;
       return builder;
    }
 
-   public static MavenPluginConfigurationElementBuilder create(MavenPluginConfigurationElementBuilder elementBuilder)
+   public static ConfigurationElementBuilder create(ConfigurationElementBuilder elementBuilder)
    {
-      MavenPluginConfigurationElementBuilder builder = new MavenPluginConfigurationElementBuilder(elementBuilder);
+      ConfigurationElementBuilder builder = new ConfigurationElementBuilder(elementBuilder);
       builder.elementBuilder = elementBuilder;
       return builder;
    }
 
-   public static MavenPluginConfigurationElementBuilder createFromExisting(MavenPluginConfigurationElement element)
+   public static ConfigurationElementBuilder createFromExisting(ConfigurationElement element)
    {
 
-      if (element instanceof MavenPluginConfigurationElementBuilder)
+      if (element instanceof ConfigurationElementBuilder)
       {
-         MavenPluginConfigurationElementBuilder elementBuilder = (MavenPluginConfigurationElementBuilder) element;
-         MavenPluginConfigurationElementBuilder builder = new MavenPluginConfigurationElementBuilder(elementBuilder);
+         ConfigurationElementBuilder elementBuilder = (ConfigurationElementBuilder) element;
+         ConfigurationElementBuilder builder = new ConfigurationElementBuilder(elementBuilder);
 
          builder.configurationElement.setName(element.getName());
          builder.configurationElement.setText(element.getText());
          builder.configurationElement.setChildren(element.getChildren());
          return builder;
 
-      } else if (element instanceof MavenPluginConfigurationElementImpl)
+      } else if (element instanceof ConfigurationElementImpl)
       {
-         MavenPluginConfigurationElementBuilder builder = new MavenPluginConfigurationElementBuilder();
+         ConfigurationElementBuilder builder = new ConfigurationElementBuilder();
 
-         builder.configurationElement = (MavenPluginConfigurationElementImpl) element;
+         builder.configurationElement = (ConfigurationElementImpl) element;
          return builder;
       } else
       {
@@ -146,21 +146,21 @@ public class MavenPluginConfigurationElementBuilder implements MavenPluginConfig
       }
    }
 
-   public MavenPluginConfigurationElementBuilder setName(String name)
+   public ConfigurationElementBuilder setName(String name)
    {
       configurationElement.setName(name);
       return this;
    }
 
-   public MavenPluginConfigurationElementBuilder createConfigurationElement(String name)
+   public ConfigurationElementBuilder createConfigurationElement(String name)
    {
-      MavenPluginConfigurationElementBuilder builder = MavenPluginConfigurationElementBuilder.create(this);
+      ConfigurationElementBuilder builder = ConfigurationElementBuilder.create(this);
       builder.setName(name);
       configurationElement.addChild(builder);
       return builder;
    }
 
-   @Override public List<MavenPluginElement> getChildren()
+   @Override public List<PluginElement> getChildren()
    {
       return configurationElement.getChildren();
    }

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/ConfigurationElementImpl.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/ConfigurationElementImpl.java
@@ -28,11 +28,11 @@ import java.util.List;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public class MavenPluginConfigurationElementImpl implements MavenPluginConfigurationElement
+public class ConfigurationElementImpl implements ConfigurationElement
 {
    private String name;
    private String text;
-   private List<MavenPluginElement> children = new ArrayList<MavenPluginElement>();
+   private List<PluginElement> children = new ArrayList<PluginElement>();
 
 
    public void setName(String name)
@@ -65,17 +65,17 @@ public class MavenPluginConfigurationElementImpl implements MavenPluginConfigura
       return text;
    }
 
-   public void addChild(MavenPluginElement element)
+   public void addChild(PluginElement element)
    {
       children.add(element);
    }
 
-   public List<MavenPluginElement> getChildren()
+   public List<PluginElement> getChildren()
    {
       return children;
    }
 
-   public void setChildren(List<MavenPluginElement> children)
+   public void setChildren(List<PluginElement> children)
    {
       this.children = children;
    }
@@ -84,7 +84,7 @@ public class MavenPluginConfigurationElementImpl implements MavenPluginConfigura
    {
       StringBuilder b = new StringBuilder();
       b.append("<").append(name).append(">");
-      for (MavenPluginElement child : children)
+      for (PluginElement child : children)
       {
          b.append(child.toString());
       }

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/ConfigurationException.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/ConfigurationException.java
@@ -25,6 +25,10 @@ package org.jboss.forge.maven.plugins;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public interface MavenPluginElement
+public class ConfigurationException extends RuntimeException
 {
+   public ConfigurationException(String s, Exception ex)
+   {
+      super(s, ex);
+   }
 }

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/ConfigurationImpl.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/ConfigurationImpl.java
@@ -30,17 +30,17 @@ import java.util.List;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public class MavenPluginConfigurationImpl implements MavenPluginConfiguration
+public class ConfigurationImpl implements Configuration
 {
    private Xpp3Dom configuration;
-   private List<MavenPluginConfigurationElement> configurationElements = new ArrayList<MavenPluginConfigurationElement>();
+   private List<ConfigurationElement> configurationElements = new ArrayList<ConfigurationElement>();
 
-   public MavenPluginConfigurationImpl()
+   public ConfigurationImpl()
    {
       configuration = new Xpp3Dom("configuration");
    }
 
-   public MavenPluginConfigurationImpl(Xpp3Dom configXml)
+   public ConfigurationImpl(Xpp3Dom configXml)
    {
       this.configuration = configXml;
       if (configuration != null)
@@ -48,7 +48,7 @@ public class MavenPluginConfigurationImpl implements MavenPluginConfiguration
 
          for (Xpp3Dom xpp3Dom : configuration.getChildren())
          {
-            MavenPluginConfigurationElementBuilder builder = MavenPluginConfigurationElementBuilder.create()
+            ConfigurationElementBuilder builder = ConfigurationElementBuilder.create()
                     .setName(xpp3Dom.getName()).setText(xpp3Dom.getValue());
             addChilds(xpp3Dom, builder);
             configurationElements.add(builder);
@@ -58,9 +58,9 @@ public class MavenPluginConfigurationImpl implements MavenPluginConfiguration
       }
    }
 
-   @Override public MavenPluginConfigurationElement getConfigurationElement(String configElement)
+   @Override public ConfigurationElement getConfigurationElement(String configElement)
    {
-      for (MavenPluginConfigurationElement configurationElement : configurationElements)
+      for (ConfigurationElement configurationElement : configurationElements)
       {
          if (configurationElement.getName().equals(configElement))
          {
@@ -74,7 +74,7 @@ public class MavenPluginConfigurationImpl implements MavenPluginConfiguration
    @Override public boolean hasConfigurationElement(String configElement)
    {
 
-      for (MavenPluginConfigurationElement configurationElement : configurationElements)
+      for (ConfigurationElement configurationElement : configurationElements)
       {
          if (configurationElement.getName().equals(configElement))
          {
@@ -85,25 +85,25 @@ public class MavenPluginConfigurationImpl implements MavenPluginConfiguration
       return false;
    }
 
-   @Override public List<MavenPluginConfigurationElement> listConfigurationElements()
+   @Override public List<ConfigurationElement> listConfigurationElements()
    {
       return configurationElements;
    }
 
-   private void addChilds(Xpp3Dom xpp3Dom, MavenPluginConfigurationElementBuilder builder)
+   private void addChilds(Xpp3Dom xpp3Dom, ConfigurationElementBuilder builder)
    {
       builder.setText(xpp3Dom.getValue());
 
       for (Xpp3Dom child : xpp3Dom.getChildren())
       {
 
-         MavenPluginConfigurationElementBuilder elementBuilder = builder.addChild(child.getName());
+         ConfigurationElementBuilder elementBuilder = builder.addChild(child.getName());
          addChilds(child, elementBuilder);
 
       }
    }
 
-   @Override public MavenPluginConfiguration addConfigurationElement(MavenPluginConfigurationElement element)
+   @Override public Configuration addConfigurationElement(ConfigurationElement element)
    {
 
       configurationElements.add(element);
@@ -113,7 +113,7 @@ public class MavenPluginConfigurationImpl implements MavenPluginConfiguration
 
    @Override public void removeConfigurationElement(String elementName)
    {
-      for (MavenPluginConfigurationElement configurationElement : configurationElements)
+      for (ConfigurationElement configurationElement : configurationElements)
       {
          if (configurationElement.getName().equals(elementName))
          {
@@ -128,7 +128,7 @@ public class MavenPluginConfigurationImpl implements MavenPluginConfiguration
       StringBuilder b = new StringBuilder();
       b.append("<configuration>");
 
-      for (MavenPluginConfigurationElement configurationElement : configurationElements)
+      for (ConfigurationElement configurationElement : configurationElements)
       {
          b.append(configurationElement.toString());
       }

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPlugin.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPlugin.java
@@ -30,9 +30,9 @@ import org.jboss.forge.project.dependencies.Dependency;
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
 
-public interface MavenPlugin extends MavenPluginElement
+public interface MavenPlugin extends PluginElement
 {
    Dependency getDependency();
 
-   MavenPluginConfiguration getConfig();
+   Configuration getConfig();
 }

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPluginAdapter.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPluginAdapter.java
@@ -22,7 +22,6 @@
 
 package org.jboss.forge.maven.plugins;
 
-import org.apache.maven.model.Plugin;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.jboss.forge.project.dependencies.Dependency;
@@ -34,7 +33,8 @@ import java.io.ByteArrayInputStream;
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
 
-public class MavenPluginAdapter extends Plugin implements MavenPlugin {
+public class MavenPluginAdapter extends org.apache.maven.model.Plugin implements MavenPlugin
+{
     public MavenPluginAdapter(MavenPlugin mavenPlugin) {
         Dependency dependency = mavenPlugin.getDependency();
 
@@ -58,8 +58,8 @@ public class MavenPluginAdapter extends Plugin implements MavenPlugin {
         }
     }
 
-    public MavenPluginAdapter(Plugin plugin) {
-        Plugin clone = plugin.clone();
+    public MavenPluginAdapter(org.apache.maven.model.Plugin plugin) {
+        org.apache.maven.model.Plugin clone = plugin.clone();
 
         setGroupId(clone.getGroupId());
         setArtifactId(clone.getArtifactId());
@@ -68,11 +68,11 @@ public class MavenPluginAdapter extends Plugin implements MavenPlugin {
     }
 
     @Override
-    public MavenPluginConfiguration getConfig() {
+    public Configuration getConfig() {
         Xpp3Dom dom = (Xpp3Dom) super.getConfiguration();
 
 
-        return new MavenPluginConfigurationImpl(dom);
+        return new ConfigurationImpl(dom);
     }
 
     @Override

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPluginBuilder.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPluginBuilder.java
@@ -27,7 +27,8 @@ import org.jboss.forge.project.dependencies.Dependency;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public class MavenPluginBuilder implements MavenPlugin, MavenPluginElement {
+public class MavenPluginBuilder implements MavenPlugin, PluginElement
+{
     private MavenPluginImpl plugin = new MavenPluginImpl();
 
     private MavenPluginBuilder() {
@@ -45,7 +46,7 @@ public class MavenPluginBuilder implements MavenPlugin, MavenPluginElement {
         return new MavenPluginBuilder(plugin);
     }
 
-    public MavenPluginBuilder setConfiguration(MavenPluginConfiguration configuration) {
+    public MavenPluginBuilder setConfiguration(Configuration configuration) {
         plugin.setConfiguration(configuration);
         return this;
     }
@@ -61,7 +62,7 @@ public class MavenPluginBuilder implements MavenPlugin, MavenPluginElement {
     }
 
     @Override
-    public MavenPluginConfiguration getConfig() {
+    public Configuration getConfig() {
         return plugin.getConfig();
     }
 
@@ -71,12 +72,12 @@ public class MavenPluginBuilder implements MavenPlugin, MavenPluginElement {
     }
 
 
-    public MavenPluginConfigurationBuilder createConfiguration() {
-        MavenPluginConfigurationBuilder builder;
+    public ConfigurationBuilder createConfiguration() {
+        ConfigurationBuilder builder;
         if (plugin.getConfig() != null) {
-            builder = MavenPluginConfigurationBuilder.create(plugin.getConfig(), this);
+            builder = ConfigurationBuilder.create(plugin.getConfig(), this);
         } else {
-            builder = MavenPluginConfigurationBuilder.create(this);
+            builder = ConfigurationBuilder.create(this);
         }
 
         plugin.setConfiguration(builder);

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPluginImpl.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPluginImpl.java
@@ -27,9 +27,10 @@ import org.jboss.forge.project.dependencies.Dependency;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public class MavenPluginImpl implements MavenPlugin {
+public class MavenPluginImpl implements MavenPlugin
+{
     private Dependency dependency;
-    private MavenPluginConfiguration configuration;
+    private Configuration configuration;
 
     public MavenPluginImpl() {
     }
@@ -50,7 +51,7 @@ public class MavenPluginImpl implements MavenPlugin {
     }
 
     @Override
-    public MavenPluginConfiguration getConfig() {
+    public Configuration getConfig() {
         return configuration;
     }
 
@@ -77,7 +78,7 @@ public class MavenPluginImpl implements MavenPlugin {
         return b.toString();
     }
 
-    public void setConfiguration(MavenPluginConfiguration configuration) {
+    public void setConfiguration(Configuration configuration) {
         this.configuration = configuration;
     }
 }

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/PluginElement.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/PluginElement.java
@@ -25,10 +25,6 @@ package org.jboss.forge.maven.plugins;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public class MavenPluginConfigurationException extends RuntimeException
+public interface PluginElement
 {
-   public MavenPluginConfigurationException(String s, Exception ex)
-   {
-      super(s, ex);
-   }
 }

--- a/project-model-maven-tests/src/test/java/org/jboss/forge/maven/mavenplugins/ConfigurationElementBuilderTest.java
+++ b/project-model-maven-tests/src/test/java/org/jboss/forge/maven/mavenplugins/ConfigurationElementBuilderTest.java
@@ -22,9 +22,9 @@
 
 package org.jboss.forge.maven.mavenplugins;
 
+import org.jboss.forge.maven.plugins.ConfigurationElementBuilder;
 import org.jboss.forge.maven.plugins.MavenPlugin;
 import org.jboss.forge.maven.plugins.MavenPluginBuilder;
-import org.jboss.forge.maven.plugins.MavenPluginConfigurationElementBuilder;
 import org.jboss.forge.project.dependencies.DependencyBuilder;
 import org.junit.Test;
 
@@ -33,7 +33,8 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public class MavenPluginConfigurationElementBuilderTest {
+public class ConfigurationElementBuilderTest
+{
     private static final String XML = "<additionalClasspathElements><additionalClasspathElement>test</additionalClasspathElement></additionalClasspathElements>";
     private static final String XML_WITH_SUB_PLUGIN = "<reportPlugins><plugin><groupId>org.codehaus.mojo</groupId><artifactId>findbugs-maven-plugin</artifactId><version>2.3.2</version></plugin></reportPlugins>";
     private static final String XML_WITH_SUB_PLUGIN_AND_CONFIGURATION = "<reportPlugins><plugin><groupId>org.codehaus.mojo</groupId><artifactId>findbugs-maven-plugin</artifactId><version>2.3.2</version><configuration><xmlOutput>true</xmlOutput></configuration></plugin></reportPlugins>";
@@ -44,7 +45,7 @@ public class MavenPluginConfigurationElementBuilderTest {
 
     @Test
     public void testCreateConfigElement() {
-        MavenPluginConfigurationElementBuilder builder = MavenPluginConfigurationElementBuilder.create()
+        ConfigurationElementBuilder builder = ConfigurationElementBuilder.create()
                 .setName("additionalClasspathElements")
                 .addChild("additionalClasspathElement").setText("test").getParentElement();
 
@@ -62,7 +63,7 @@ public class MavenPluginConfigurationElementBuilderTest {
                                 .setVersion("2.3.2")
                 );
 
-        MavenPluginConfigurationElementBuilder builder = MavenPluginConfigurationElementBuilder.create()
+        ConfigurationElementBuilder builder = ConfigurationElementBuilder.create()
                 .setName("reportPlugins")
                 .addChild(findbugsPlugin);
 
@@ -84,7 +85,7 @@ public class MavenPluginConfigurationElementBuilderTest {
                 .getOrigin();
 
 
-        MavenPluginConfigurationElementBuilder builder = MavenPluginConfigurationElementBuilder.create()
+        ConfigurationElementBuilder builder = ConfigurationElementBuilder.create()
                 .setName("reportPlugins")
                 .addChild(findbugsPlugin);
 

--- a/project-model-maven-tests/src/test/java/org/jboss/forge/maven/mavenplugins/ConfigurationImplTest.java
+++ b/project-model-maven-tests/src/test/java/org/jboss/forge/maven/mavenplugins/ConfigurationImplTest.java
@@ -25,10 +25,10 @@ package org.jboss.forge.maven.mavenplugins;
 import org.apache.maven.model.Plugin;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
+import org.jboss.forge.maven.plugins.Configuration;
 import org.jboss.forge.maven.plugins.MavenPluginAdapter;
-import org.jboss.forge.maven.plugins.MavenPluginConfiguration;
-import org.jboss.forge.maven.plugins.MavenPluginConfigurationElement;
-import org.jboss.forge.maven.plugins.MavenPluginConfigurationElementBuilder;
+import org.jboss.forge.maven.plugins.ConfigurationElement;
+import org.jboss.forge.maven.plugins.ConfigurationElementBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,10 +43,10 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public class MavenPluginConfigurationImplTest
+public class ConfigurationImplTest
 {
 
-   private MavenPluginConfiguration pluginConfiguration;
+   private Configuration pluginConfiguration;
 
    @Before
    public void setup() throws Exception
@@ -72,9 +72,9 @@ public class MavenPluginConfigurationImplTest
    @Test
    public void testListConfigurationElements() throws Exception
    {
-      List<MavenPluginConfigurationElement> plugins = pluginConfiguration.listConfigurationElements();
+      List<ConfigurationElement> plugins = pluginConfiguration.listConfigurationElements();
       assertThat(plugins.size(), is(1));
-      MavenPluginConfigurationElement configurationElement = plugins.get(0);
+      ConfigurationElement configurationElement = plugins.get(0);
       assertThat(configurationElement.getName(), is("reportPlugins"));
       assertFalse(configurationElement.isPlugin());
    }
@@ -82,12 +82,12 @@ public class MavenPluginConfigurationImplTest
    @Test
    public void testAddConfigurationElement() throws Exception
    {
-      List<MavenPluginConfigurationElement> plugins = pluginConfiguration.listConfigurationElements();
+      List<ConfigurationElement> plugins = pluginConfiguration.listConfigurationElements();
       int pluginSize = plugins.size();
       assertThat(pluginSize, is(1));
 
-      MavenPluginConfigurationElementBuilder element =
-              MavenPluginConfigurationElementBuilder.create()
+      ConfigurationElementBuilder element =
+              ConfigurationElementBuilder.create()
                       .setName("testElement");
 
       pluginConfiguration.addConfigurationElement(element);

--- a/project-model-maven-tests/src/test/java/org/jboss/forge/maven/mavenplugins/MavenPluginAdapterTest.java
+++ b/project-model-maven-tests/src/test/java/org/jboss/forge/maven/mavenplugins/MavenPluginAdapterTest.java
@@ -25,8 +25,8 @@ package org.jboss.forge.maven.mavenplugins;
 import org.apache.maven.model.Plugin;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
+import org.jboss.forge.maven.plugins.Configuration;
 import org.jboss.forge.maven.plugins.MavenPluginAdapter;
-import org.jboss.forge.maven.plugins.MavenPluginConfiguration;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -43,7 +43,7 @@ public class MavenPluginAdapterTest
    public void testGetPluginConfiguration() throws Exception
    {
       MavenPluginAdapter adapter = new MavenPluginAdapter(createMavenPlugin());
-      MavenPluginConfiguration pluginConfiguration = adapter.getConfig();
+      Configuration pluginConfiguration = adapter.getConfig();
       assertNotNull(pluginConfiguration);
    }
 

--- a/project-model-maven/src/main/java/org/jboss/forge/maven/facets/MavenPluginFacetImpl.java
+++ b/project-model-maven/src/main/java/org/jboss/forge/maven/facets/MavenPluginFacetImpl.java
@@ -23,7 +23,6 @@
 package org.jboss.forge.maven.facets;
 
 import org.apache.maven.model.Model;
-import org.apache.maven.model.Plugin;
 import org.jboss.forge.maven.MavenCoreFacet;
 import org.jboss.forge.maven.MavenPluginFacet;
 import org.jboss.forge.maven.facets.exceptions.PluginNotFoundException;
@@ -70,10 +69,10 @@ public class MavenPluginFacetImpl extends BaseFacet implements MavenPluginFacet,
     @Override
     public List<MavenPlugin> listConfiguredPlugins() {
         MavenCoreFacet mavenCoreFacet = project.getFacet(MavenCoreFacet.class);
-        List<Plugin> pomPlugins = mavenCoreFacet.getPOM().getBuild().getPlugins();
+        List<org.apache.maven.model.Plugin> pomPlugins = mavenCoreFacet.getPOM().getBuild().getPlugins();
         List<MavenPlugin> plugins = new ArrayList<MavenPlugin>();
 
-        for (Plugin plugin : pomPlugins) {
+        for (org.apache.maven.model.Plugin plugin : pomPlugins) {
             MavenPluginAdapter adapter = new MavenPluginAdapter(plugin);
             MavenPluginBuilder pluginBuilder = MavenPluginBuilder.create()
                     .setDependency(
@@ -134,8 +133,8 @@ public class MavenPluginFacetImpl extends BaseFacet implements MavenPluginFacet,
     @Override
     public void removePlugin(Dependency dependency) {
         MavenCoreFacet mavenCoreFacet = project.getFacet(MavenCoreFacet.class);
-        List<Plugin> pomPlugins = mavenCoreFacet.getPOM().getBuild().getPlugins();
-        for (Plugin pomPlugin : pomPlugins) {
+        List<org.apache.maven.model.Plugin> pomPlugins = mavenCoreFacet.getPOM().getBuild().getPlugins();
+        for (org.apache.maven.model.Plugin pomPlugin : pomPlugins) {
             if (pomPlugin.getGroupId().equals(dependency.getGroupId())
                     && pomPlugin.getArtifactId().equals(dependency.getArtifactId())) {
                 Model pom = mavenCoreFacet.getPOM();


### PR DESCRIPTION
I left MavenPlugin, MavenPluginAdaptor, MavenPluginBuilder and MavenPluginImpl intentionally the same, otherwise you would get a lot of messy imports when using this API in a plugin. 
