### PR TITLE
Seamforge 112

### DIFF
--- a/maven-api/src/main/java/org/jboss/forge/maven/MavenPluginFacet.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/MavenPluginFacet.java
@@ -25,6 +25,7 @@ package org.jboss.forge.maven;
 import org.jboss.forge.maven.plugins.MavenPlugin;
 import org.jboss.forge.project.Facet;
 import org.jboss.forge.project.dependencies.Dependency;
+import org.jboss.forge.project.dependencies.DependencyRepository;
 
 import java.util.List;
 
@@ -33,6 +34,32 @@ import java.util.List;
  */
 public interface MavenPluginFacet extends Facet
 {
+   public enum KnownRepository
+   {
+      CENTRAL("http://repo1.maven.org/maven2/"),
+      JBOSS_NEXUS("http://repository.jboss.org/nexus/content/groups/public"),
+      JBOSS_LEGACY("http://repository.jboss.org/maven2"),
+      JAVA_NET("http://download.java.net/maven/2/");
+
+      private final String url;
+
+      private KnownRepository(String url)
+      {
+         this.url = url;
+      }
+
+      public String getUrl()
+      {
+         return url;
+      }
+
+      public String getId()
+      {
+         return this.name();
+      }
+   }
+
+
    List<MavenPlugin> listConfiguredPlugins();
 
    boolean hasPlugin(Dependency dependency);
@@ -42,4 +69,37 @@ public interface MavenPluginFacet extends Facet
    void addPlugin(MavenPlugin plugin);
 
    void removePlugin(Dependency dependency);
+
+   /**
+    * Add a {@link KnownRepository} to the project build system. This is where dependencies can be found, downloaded,
+    * and installed to the project build script.
+    */
+   public void addPluginRepository(KnownRepository repository);
+
+   /**
+    * Add a repository to the project build system. This is where dependencies can be found, downloaded, and installed
+    * to the project build script.
+    */
+   public void addPluginRepository(String name, String url);
+
+   /**
+    * Return true if the given {@link KnownRepository} is already registered in this project's build system.
+    */
+   public boolean hasPluginRepository(KnownRepository repository);
+
+   /**
+    * Return true if the given repository URL is already registered in this project's build system.
+    */
+   public boolean hasPluginRepository(String url);
+
+   /**
+    * Remove the given {@link org.jboss.forge.project.dependencies.DependencyRepository} from the current project. Return true if the repository was removed;
+    * return false otherwise. Return the removed repository, or null if no repository was removed.
+    */
+   public DependencyRepository removePluginRepository(String url);
+
+   /**
+    * Get the list of plugin repositories for which this project is currently configured to use in dependency resolution.
+    */
+   public List<DependencyRepository> getPluginRepositories();
 }

--- a/shell/src/main/java/org/jboss/forge/shell/plugins/builtin/project/PluginRepositoryCompleter.java
+++ b/shell/src/main/java/org/jboss/forge/shell/plugins/builtin/project/PluginRepositoryCompleter.java
@@ -1,0 +1,31 @@
+package org.jboss.forge.shell.plugins.builtin.project;
+
+import org.jboss.forge.maven.MavenPluginFacet;
+import org.jboss.forge.project.Project;
+import org.jboss.forge.project.dependencies.DependencyRepository;
+import org.jboss.forge.project.facets.DependencyFacet;
+import org.jboss.forge.shell.completer.SimpleTokenCompleter;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PluginRepositoryCompleter extends SimpleTokenCompleter
+{
+   @Inject
+   private Project project;
+
+   @Override public List<Object> getCompletionTokens()
+   {
+      MavenPluginFacet deps = project.getFacet(MavenPluginFacet.class);
+      List<DependencyRepository> repositories = deps.getPluginRepositories();
+
+      List<Object> result = new ArrayList<Object>();
+      for (DependencyRepository dependencyRepository : repositories)
+      {
+         result.add(dependencyRepository.getUrl());
+      }
+
+      return result;
+   }
+}


### PR DESCRIPTION
Implemented it with the following decisions:
-Introduce new commands instead of a flag because plugin-repos are completely separated from dependency-repos in a pom file.
-The getPluginRepositories method returns a List of type DependencyRepository. Maybe we should introduce a PluginRepository instead.
-Implemented the enum KnownRepository again in DependencyFacet so that we can have a different list of known repositories for dependencies and plugins later.
