### PR TITLE
Inital version of the maven-profile-api

### DIFF
--- a/maven-api/src/main/java/org/jboss/forge/maven/profiles/Profile.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/profiles/Profile.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  * JBoss, Home of Professional Open Source
+ *  * Copyright 2011, Red Hat, Inc., and individual contributors
+ *  * by the @authors tag. See the copyright.txt in the distribution for a
+ *  * full listing of individual contributors.
+ *  *
+ *  * This is free software; you can redistribute it and/or modify it
+ *  * under the terms of the GNU Lesser General Public License as
+ *  * published by the Free Software Foundation; either version 2.1 of
+ *  * the License, or (at your option) any later version.
+ *  *
+ *  * This software is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this software; if not, write to the Free
+ *  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.forge.maven.profiles;
+
+import org.jboss.forge.project.dependencies.Dependency;
+import org.jboss.forge.project.dependencies.DependencyRepository;
+
+import java.util.List;
+import java.util.Properties;
+
+public interface Profile
+{
+   String getId();
+
+   boolean isActiveByDefault();
+
+   List<Dependency> listDependencies();
+
+   List<DependencyRepository> listRepositories();
+
+   Properties getProperties();
+}

--- a/maven-api/src/main/java/org/jboss/forge/maven/profiles/ProfileAdapter.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/profiles/ProfileAdapter.java
@@ -1,0 +1,59 @@
+/*
+ *
+ *  * JBoss, Home of Professional Open Source
+ *  * Copyright 2011, Red Hat, Inc., and individual contributors
+ *  * by the @authors tag. See the copyright.txt in the distribution for a
+ *  * full listing of individual contributors.
+ *  *
+ *  * This is free software; you can redistribute it and/or modify it
+ *  * under the terms of the GNU Lesser General Public License as
+ *  * published by the Free Software Foundation; either version 2.1 of
+ *  * the License, or (at your option) any later version.
+ *  *
+ *  * This software is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this software; if not, write to the Free
+ *  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.forge.maven.profiles;
+
+import org.apache.maven.model.Activation;
+import org.apache.maven.model.Repository;
+import org.jboss.forge.maven.dependencies.MavenDependencyAdapter;
+import org.jboss.forge.project.dependencies.Dependency;
+import org.jboss.forge.project.dependencies.DependencyRepository;
+
+public class ProfileAdapter extends org.apache.maven.model.Profile
+{
+
+   public ProfileAdapter(Profile profile)
+   {
+      setId(profile.getId());
+      Activation activation = new Activation();
+      activation.setActiveByDefault(profile.isActiveByDefault());
+
+      setActivation(activation);
+
+      for (Dependency dependency : profile.listDependencies())
+      {
+         getDependencies().add(new MavenDependencyAdapter(dependency));
+      }
+
+      for (DependencyRepository repository : profile.listRepositories())
+      {
+         Repository mavenRepository = new Repository();
+         mavenRepository.setId(repository.getId());
+         mavenRepository.setUrl(repository.getUrl());
+         getRepositories().add(mavenRepository);
+      }
+
+      setProperties(profile.getProperties());
+   }
+}

--- a/maven-api/src/main/java/org/jboss/forge/maven/profiles/ProfileBuilder.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/profiles/ProfileBuilder.java
@@ -1,0 +1,119 @@
+/*
+ *
+ *  * JBoss, Home of Professional Open Source
+ *  * Copyright 2011, Red Hat, Inc., and individual contributors
+ *  * by the @authors tag. See the copyright.txt in the distribution for a
+ *  * full listing of individual contributors.
+ *  *
+ *  * This is free software; you can redistribute it and/or modify it
+ *  * under the terms of the GNU Lesser General Public License as
+ *  * published by the Free Software Foundation; either version 2.1 of
+ *  * the License, or (at your option) any later version.
+ *  *
+ *  * This software is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this software; if not, write to the Free
+ *  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.forge.maven.profiles;
+
+import org.jboss.forge.project.dependencies.Dependency;
+import org.jboss.forge.project.dependencies.DependencyRepository;
+
+import java.util.List;
+import java.util.Properties;
+
+public class ProfileBuilder implements Profile
+{
+   private ProfileImpl profile;
+
+   private ProfileBuilder(ProfileImpl profile)
+   {
+      this.profile = profile;
+   }
+
+   public static ProfileBuilder create()
+   {
+      return new ProfileBuilder(new ProfileImpl());
+   }
+
+   public static ProfileBuilder create(Profile profile)
+   {
+      if (profile instanceof ProfileImpl)
+      {
+         return new ProfileBuilder((ProfileImpl) profile);
+      } else if (profile instanceof ProfileBuilder)
+      {
+         return new ProfileBuilder(((ProfileBuilder) profile).profile);
+      }
+
+      throw new IllegalArgumentException("Profile of type '" + profile.getClass().getName() + "' is not supported");
+   }
+
+   @Override public String getId()
+   {
+      return profile.getId();
+   }
+
+   @Override public boolean isActiveByDefault()
+   {
+      return profile.isActiveByDefault();
+   }
+
+   @Override public List<Dependency> listDependencies()
+   {
+      return profile.listDependencies();
+   }
+
+   @Override public List<DependencyRepository> listRepositories()
+   {
+      return profile.listRepositories();
+   }
+
+   @Override public Properties getProperties()
+   {
+      return profile.getProperties();
+   }
+
+   public ProfileBuilder setId(String id)
+   {
+      profile.setId(id);
+      return this;
+   }
+
+   public ProfileBuilder setActiveByDefault(boolean activeByDefault)
+   {
+      profile.setActivateByDefault(activeByDefault);
+      return this;
+   }
+
+   public ProfileBuilder addDependency(Dependency dependency)
+   {
+      profile.listDependencies().add(dependency);
+      return this;
+   }
+
+   public ProfileBuilder addRepository(DependencyRepository repository)
+   {
+      profile.listRepositories().add(repository);
+      return this;
+   }
+
+   public ProfileBuilder addProperty(String key, String value)
+   {
+      profile.getProperties().setProperty(key, value);
+      return this;
+   }
+
+   public org.apache.maven.model.Profile getAsMavenProfile()
+   {
+      return new ProfileAdapter(profile);
+   }
+}

--- a/maven-api/src/main/java/org/jboss/forge/maven/profiles/ProfileImpl.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/profiles/ProfileImpl.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *  * JBoss, Home of Professional Open Source
+ *  * Copyright 2011, Red Hat, Inc., and individual contributors
+ *  * by the @authors tag. See the copyright.txt in the distribution for a
+ *  * full listing of individual contributors.
+ *  *
+ *  * This is free software; you can redistribute it and/or modify it
+ *  * under the terms of the GNU Lesser General Public License as
+ *  * published by the Free Software Foundation; either version 2.1 of
+ *  * the License, or (at your option) any later version.
+ *  *
+ *  * This software is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this software; if not, write to the Free
+ *  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.forge.maven.profiles;
+
+import org.jboss.forge.project.dependencies.Dependency;
+import org.jboss.forge.project.dependencies.DependencyRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+public class ProfileImpl implements Profile
+{
+   private String id;
+   private boolean activateByDefault;
+   private List<Dependency> dependencies = new ArrayList<Dependency>();
+   private List<DependencyRepository> repositories = new ArrayList<DependencyRepository>();
+   private Properties properties = new Properties();
+
+   @Override public String getId()
+   {
+      return id;
+   }
+
+   @Override public boolean isActiveByDefault()
+   {
+      return activateByDefault;
+   }
+
+   @Override public List<Dependency> listDependencies()
+   {
+      return dependencies;
+   }
+
+   @Override public List<DependencyRepository> listRepositories()
+   {
+      return repositories;
+   }
+
+   @Override public Properties getProperties()
+   {
+      return properties;
+   }
+
+   public void setId(String id)
+   {
+      this.id = id;
+   }
+
+   public void setActivateByDefault(boolean activateByDefault)
+   {
+      this.activateByDefault = activateByDefault;
+   }
+}

--- a/maven-api/src/test/java/org/jboss/forge/maven/profiles/ProfileAdapterTest.java
+++ b/maven-api/src/test/java/org/jboss/forge/maven/profiles/ProfileAdapterTest.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *  * JBoss, Home of Professional Open Source
+ *  * Copyright 2011, Red Hat, Inc., and individual contributors
+ *  * by the @authors tag. See the copyright.txt in the distribution for a
+ *  * full listing of individual contributors.
+ *  *
+ *  * This is free software; you can redistribute it and/or modify it
+ *  * under the terms of the GNU Lesser General Public License as
+ *  * published by the Free Software Foundation; either version 2.1 of
+ *  * the License, or (at your option) any later version.
+ *  *
+ *  * This software is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this software; if not, write to the Free
+ *  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.forge.maven.profiles;
+
+import org.jboss.forge.project.dependencies.DependencyBuilder;
+import org.jboss.forge.project.dependencies.DependencyRepositoryImpl;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ProfileAdapterTest
+{
+   @Test
+   public void testCreateFromProfile()
+   {
+      ProfileBuilder profileBuilder =
+              ProfileBuilder.create()
+                      .setId("myid")
+                      .setActiveByDefault(true)
+                      .addDependency(DependencyBuilder.create("mygroupId:myartifactId"))
+                      .addDependency(DependencyBuilder.create("mygroupId:mysecond"))
+                      .addRepository(new DependencyRepositoryImpl("id", "url"));
+
+      ProfileAdapter profileAdapter = new ProfileAdapter(profileBuilder);
+      assertThat(profileAdapter.getId(), is(profileBuilder.getId()));
+      assertThat(profileAdapter.getActivation().isActiveByDefault(), is(true));
+      assertThat(profileAdapter.getDependencies().size(), is(2));
+      assertThat(profileAdapter.getRepositories().size(), is(1));
+   }
+}

--- a/maven-api/src/test/java/org/jboss/forge/maven/profiles/ProfileBuilderTest.java
+++ b/maven-api/src/test/java/org/jboss/forge/maven/profiles/ProfileBuilderTest.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *  * JBoss, Home of Professional Open Source
+ *  * Copyright 2011, Red Hat, Inc., and individual contributors
+ *  * by the @authors tag. See the copyright.txt in the distribution for a
+ *  * full listing of individual contributors.
+ *  *
+ *  * This is free software; you can redistribute it and/or modify it
+ *  * under the terms of the GNU Lesser General Public License as
+ *  * published by the Free Software Foundation; either version 2.1 of
+ *  * the License, or (at your option) any later version.
+ *  *
+ *  * This software is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  * Lesser General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU Lesser General Public
+ *  * License along with this software; if not, write to the Free
+ *  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.forge.maven.profiles;
+
+import org.apache.maven.model.Profile;
+import org.jboss.forge.project.dependencies.DependencyBuilder;
+import org.jboss.forge.project.dependencies.DependencyRepositoryImpl;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class ProfileBuilderTest
+{
+   @Test
+   public void testCreateWithExistingProfile() throws Exception
+   {
+      ProfileImpl profile = new ProfileImpl();
+      profile.setId("testprofile");
+
+      ProfileBuilder profileBuilder = ProfileBuilder.create(profile);
+      assertThat(profileBuilder.getId(), is(profile.getId()));
+   }
+
+   @Test
+   public void testCreate()
+   {
+      ProfileBuilder profileBuilder = ProfileBuilder.create();
+      assertNotNull(profileBuilder);
+   }
+
+   @Test
+   public void testMethodChaining()
+   {
+      ProfileBuilder profileBuilder =
+              ProfileBuilder.create()
+                      .setId("myid")
+                      .setActiveByDefault(true)
+                      .addDependency(DependencyBuilder.create("mygroupId:myartifactId"))
+                      .addRepository(new DependencyRepositoryImpl("id", "url"));
+
+      assertTrue(profileBuilder.isActiveByDefault());
+   }
+
+   @Test
+   public void testAsMavenProfile()
+   {
+      ProfileBuilder profileBuilder =
+              ProfileBuilder.create()
+                      .setId("myid")
+                      .setActiveByDefault(true)
+                      .addDependency(DependencyBuilder.create("mygroupId:myartifactId"))
+                      .addRepository(new DependencyRepositoryImpl("id", "url"));
+      Profile mavenProfile = profileBuilder.getAsMavenProfile();
+      assertThat(mavenProfile.getId(), is(profileBuilder.getId()));
+   }
+
+   @Test
+   public void testAddProperty()
+   {
+      ProfileBuilder profileBuilder =
+              ProfileBuilder.create()
+                      .addProperty("prop1", "val1")
+                      .addProperty("prop2", "val2")
+                      .addProperty("prop3", "prop3");
+
+      Profile mavenProfile = profileBuilder.getAsMavenProfile();
+      assertThat(mavenProfile.getProperties().size(), is(3));
+   }
+}


### PR DESCRIPTION
Hi Lincoln,

For a few plugins (e.g. Arquillian, Sonar) I needed to create new Maven profiles. The Maven API is ugly as usual so I created a simple builder API for it which would be nice to have in the Core.

Paul
