### PR TITLE
Fixed SEAMFORGE-163

### DIFF
--- a/shell/src/test/java/org/jboss/forge/shell/test/plugins/builtin/ChangeDirectoryPluginTest.java
+++ b/shell/src/test/java/org/jboss/forge/shell/test/plugins/builtin/ChangeDirectoryPluginTest.java
@@ -130,7 +130,11 @@ public class ChangeDirectoryPluginTest extends AbstractShellTest
 
       String parentPath = parent.getFullyQualifiedName();
 
-      shell.execute("cd " + parentPath);
+      if (parentPath.indexOf(' ') == -1) {
+         shell.execute("cd " + parentPath);
+      } else {
+         shell.execute("cd '" + parentPath + "'");  // Could this work for all any OS or do we need OSUtils.isWindows()?
+      }
 
       Resource<?> newDir = shell.getCurrentResource();
       assertEquals(newDir.getFullyQualifiedName(), parent.getFullyQualifiedName());


### PR DESCRIPTION
Seam Forge did not handle spaces in filenames/directories on Windows (XP)
