### PR TITLE
Fixed SEAMFORGE-10

### DIFF
--- a/dev-plugins/src/main/java/org/jboss/forge/dev/mvn/MvnShellPlugin.java
+++ b/dev-plugins/src/main/java/org/jboss/forge/dev/mvn/MvnShellPlugin.java
@@ -36,6 +36,7 @@ import org.jboss.forge.shell.plugins.RequiresFacet;
 import org.jboss.forge.shell.plugins.RequiresProject;
 import org.jboss.forge.shell.plugins.Topic;
 import org.jboss.forge.shell.util.NativeSystemCall;
+import org.jboss.forge.shell.util.OSUtils;
 
 /**
  * @author Mike Brock .
@@ -60,11 +61,15 @@ public class MvnShellPlugin implements Plugin
    {
       if (shell.getCurrentProject() != null)
       {
-         NativeSystemCall.execFromPath("mvn", parms, out, shell.getCurrentProject().getProjectRoot());
+         NativeSystemCall.execFromPath(getMvnCommand(), parms, out, shell.getCurrentProject().getProjectRoot());
       }
       else
       {
-         NativeSystemCall.execFromPath("mvn", parms, out, shell.getCurrentDirectory());
+         NativeSystemCall.execFromPath(getMvnCommand(), parms, out, shell.getCurrentDirectory());
       }
+   }
+   private String getMvnCommand()
+   {
+      return OSUtils.isWindows() ? "mvn.bat" : "mvn";
    }
 }

--- a/project-model-maven/src/main/java/org/jboss/forge/maven/facets/JavaExecutionFacetImpl.java
+++ b/project-model-maven/src/main/java/org/jboss/forge/maven/facets/JavaExecutionFacetImpl.java
@@ -30,6 +30,7 @@ import org.jboss.forge.shell.ShellPrintWriter;
 import org.jboss.forge.shell.plugins.Alias;
 import org.jboss.forge.shell.plugins.RequiresFacet;
 import org.jboss.forge.shell.util.NativeSystemCall;
+import org.jboss.forge.shell.util.OSUtils;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -63,12 +64,16 @@ public class JavaExecutionFacetImpl extends BaseFacet implements JavaExecutionFa
       executeClass(commandBuilder.build());
    }
 
+   private String getMvnCommand()
+   {
+      return OSUtils.isWindows() ? "mvn.bat" : "mvn";
+   }
 
    private void executeClass(String[] mvnArguments)
    {
       try
       {
-         NativeSystemCall.execFromPath("mvn", mvnArguments, out, project.getProjectRoot());
+         NativeSystemCall.execFromPath(getMvnCommand(), mvnArguments, out, project.getProjectRoot());
       } catch (IOException e)
       {
          e.printStackTrace();
@@ -81,7 +86,7 @@ public class JavaExecutionFacetImpl extends BaseFacet implements JavaExecutionFa
 
       try
       {
-         NativeSystemCall.execFromPath("mvn", compileArgs, out, project.getProjectRoot());
+         NativeSystemCall.execFromPath(getMvnCommand(), compileArgs, out, project.getProjectRoot());
       } catch (IOException e)
       {
          throw new RuntimeException("Error while invoking mvn test-compile", e);
@@ -125,7 +130,7 @@ public class JavaExecutionFacetImpl extends BaseFacet implements JavaExecutionFa
       {
          if (arguments.length > 0)
          {
-            StringBuilder argBuilder = new StringBuilder("-Dexec.args=\"");
+            StringBuilder argBuilder = new StringBuilder("-Dexec.args='");
 
             boolean first = true;
             for (String argument : arguments)
@@ -138,7 +143,7 @@ public class JavaExecutionFacetImpl extends BaseFacet implements JavaExecutionFa
                first = false;
             }
 
-            argBuilder.append("\" ");
+            argBuilder.append("' ");
             commands.add(argBuilder.toString());
 
          }


### PR DESCRIPTION
NativeSystemCall.execFromPath("mvn" ...) was not working on Windows (XP), but a fully qualified command like NativeSystemCall.execFromPath("mvn.bat" ...) did work!

This may be important for other NativeSystemCall.execFromPath calls!

Fix for the mvn parameter -Dexec.args handling multiple string arguments (spaces) is also included.
