### PR TITLE
Seamforge 187

### DIFF
--- a/project-model-maven/src/main/java/org/jboss/forge/maven/facets/MavenPackagingFacet.java
+++ b/project-model-maven/src/main/java/org/jboss/forge/maven/facets/MavenPackagingFacet.java
@@ -31,6 +31,7 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import org.apache.maven.cli.MavenCli;
+import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.jboss.forge.ForgeEnvironment;
 import org.jboss.forge.maven.MavenCoreFacet;
@@ -181,6 +182,12 @@ public class MavenPackagingFacet extends BaseFacet implements PackagingFacet, Fa
    {
       MavenCoreFacet mavenFacet = project.getFacet(MavenCoreFacet.class);
       Model pom = mavenFacet.getPOM();
+      Build build = pom.getBuild();
+      if (build == null)
+      {
+    	 build = new Build();
+    	 pom.setBuild(build);
+      }
       pom.getBuild().setFinalName(finalName);
       mavenFacet.setPOM(pom);
    }

--- a/shell/src/test/java/org/jboss/forge/shell/test/plugins/builtin/NewProjectPluginTest.java
+++ b/shell/src/test/java/org/jboss/forge/shell/test/plugins/builtin/NewProjectPluginTest.java
@@ -17,9 +17,20 @@
 package org.jboss.forge.shell.test.plugins.builtin;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import java.util.List;
+
+import org.jboss.forge.maven.facets.MavenJavaSourceFacet;
+import org.jboss.forge.maven.facets.MavenPackagingFacet;
+import org.jboss.forge.project.Facet;
 import org.jboss.forge.project.Project;
+import org.jboss.forge.project.facets.JavaSourceFacet;
+import org.jboss.forge.project.facets.MetadataFacet;
+import org.jboss.forge.project.packaging.PackagingType;
 import org.jboss.forge.resources.DirectoryResource;
 import org.jboss.forge.shell.Shell;
 import org.jboss.forge.test.AbstractShellTest;
@@ -34,7 +45,7 @@ import org.junit.Test;
 public class NewProjectPluginTest extends AbstractShellTest
 {
    @Test
-   public void testCreateProject() throws Exception
+   public void testCreateJavaProject() throws Exception
    {
       Shell shell = getShell();
       DirectoryResource origin = shell.getCurrentDirectory();
@@ -47,4 +58,109 @@ public class NewProjectPluginTest extends AbstractShellTest
       assertEquals(created, project.getProjectRoot());
       assertNotSame(origin, created);
    }
+   
+   @Test
+   public void testCreateProjectWithGroup() throws Exception
+   {
+	      getShell().setCurrentResource(createTempFolder());
+	      queueInputLines("");
+	      getShell().execute("new-project --named test --groupId com.test --type jar");
+	      Project project = getProject();
+	      assertEquals("com.test", project.getFacet(MetadataFacet.class).getTopLevelPackage());
+		  assertEquals("com.test", project.getFacet(MavenJavaSourceFacet.class).getBasePackage());
+		  assertEquals(PackagingType.JAR, project.getFacet(MavenPackagingFacet.class).getPackagingType());
+   }
+ 
+   @Test
+   public void testCreateProjectWithDefaultType() throws Exception
+   {
+	      getShell().setCurrentResource(createTempFolder());
+	      queueInputLines("");
+	      getShell().execute("new-project --named test --groupId com.test");
+	      Project project = getProject();
+	      assertEquals("com.test", project.getFacet(MetadataFacet.class).getTopLevelPackage());
+		  assertEquals("com.test", project.getFacet(MavenJavaSourceFacet.class).getBasePackage());
+		  assertEquals(PackagingType.JAR, project.getFacet(MavenPackagingFacet.class).getPackagingType());
+   }
+ 
+   @Test
+   public void testCreatePomProject() throws Exception
+   {
+	      getShell().setCurrentResource(createTempFolder());
+	      queueInputLines("");
+	      getShell().execute("new-project --named test --groupId com.test --type pom");
+	      Project project = getProject();
+	      assertEquals("com.test", project.getFacet(MetadataFacet.class).getTopLevelPackage());
+		  assertTrue(!project.hasFacet(MavenJavaSourceFacet.class));
+		  assertEquals(PackagingType.BASIC, project.getFacet(MavenPackagingFacet.class).getPackagingType());
+   }
+
+   /**
+    * 
+    * Tests trying to create a zip (invalid) project, then changing to jar
+    * @throws Exception
+    */
+   @Test
+   public void testTryCreateUnSupportedProject() throws Exception
+   {
+	      getShell().setCurrentResource(createTempFolder());
+	      queueInputLines("", "2");
+	      getShell().execute("new-project --named test --groupId com.test --type zip");
+	      Project project = getProject();
+	      assertEquals("com.test", project.getFacet(MetadataFacet.class).getTopLevelPackage());
+		  assertEquals("com.test", project.getFacet(MavenJavaSourceFacet.class).getBasePackage());
+		  assertEquals(PackagingType.JAR, project.getFacet(MavenPackagingFacet.class).getPackagingType());
+   }
+
+   @Test
+   public void testCreateWarProject() throws Exception
+   {
+	      getShell().setCurrentResource(createTempFolder());
+	      queueInputLines("");
+	      getShell().execute("new-project --named test --groupId com.test --type war");
+	      Project project = getProject();
+	      assertEquals("com.test", project.getFacet(MetadataFacet.class).getTopLevelPackage());
+		  assertEquals("com.test", project.getFacet(MavenJavaSourceFacet.class).getBasePackage());
+		  assertEquals(PackagingType.WAR, project.getFacet(MavenPackagingFacet.class).getPackagingType());
+   }
+
+   @Test
+   public void testCreateJarProjectWithMain() throws Exception
+   {
+	      getShell().setCurrentResource(createTempFolder());
+	      queueInputLines("");
+	      getShell().execute("new-project --named test --groupId com.test --type jar createMain");
+	      Project project = getProject();
+	      assertEquals("com.test", project.getFacet(MetadataFacet.class).getTopLevelPackage());
+		  assertEquals("com.test", project.getFacet(MavenJavaSourceFacet.class).getBasePackage());
+		  assertEquals(PackagingType.JAR, project.getFacet(MavenPackagingFacet.class).getPackagingType());
+		  assertNotNull(project.getFacet(JavaSourceFacet.class).getJavaResource("src/main/java/com/test/Main.java"));
+   }
+
+   @Test
+   public void testCreatePomProjectWithMain() throws Exception
+   {
+	      getShell().setCurrentResource(createTempFolder());
+	      queueInputLines("");
+	      getShell().execute("new-project --named test --groupId com.test --type pom createMain");
+	      Project project = getProject();
+	      assertEquals("com.test", project.getFacet(MetadataFacet.class).getTopLevelPackage());
+		  assertTrue(!project.hasFacet(MavenJavaSourceFacet.class));
+		  assertEquals(PackagingType.BASIC, project.getFacet(MavenPackagingFacet.class).getPackagingType());
+		  assertTrue(!project.hasFacet(JavaSourceFacet.class));
+		  assertTrue(!project.getProjectRoot().getChildDirectory("src").exists());
+   }
+
+   @Test
+   public void testCreateProjectBadGroupId() throws Exception
+   {
+	      getShell().setCurrentResource(createTempFolder());
+	      queueInputLines("com.test", "");
+	      getShell().execute("new-project --named test --groupId com# --type jar");
+	      Project project = getProject();
+	      assertEquals("com.test", project.getFacet(MetadataFacet.class).getTopLevelPackage());
+		  assertEquals("com.test", project.getFacet(MavenJavaSourceFacet.class).getBasePackage());
+		  assertEquals(PackagingType.JAR, project.getFacet(MavenPackagingFacet.class).getPackagingType());
+   }
+   
 }

--- a/test-harness/src/main/java/org/jboss/forge/test/AbstractShellTest.java
+++ b/test-harness/src/main/java/org/jboss/forge/test/AbstractShellTest.java
@@ -39,6 +39,7 @@ import org.jboss.arquillian.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.forge.Root;
 import org.jboss.forge.project.Project;
+import org.jboss.forge.project.packaging.PackagingType;
 import org.jboss.forge.project.services.ResourceFactory;
 import org.jboss.forge.resources.DirectoryResource;
 import org.jboss.forge.resources.FileResource;
@@ -171,12 +172,17 @@ public abstract class AbstractShellTest
       return project.get();
    }
 
+   protected Project initializeProject(PackagingType type) throws IOException
+   {
+	      getShell().setCurrentResource(createTempFolder());
+	      queueInputLines("", "Y");
+	      getShell().execute("new-project --named test --groupId com.test --type " + type.toString());
+	      return getProject();
+	   
+   }
    protected Project initializeJavaProject() throws IOException
    {
-      getShell().setCurrentResource(createTempFolder());
-      queueInputLines("", "");
-      getShell().execute("new-project --named test --topLevelPackage com.test");
-      return getProject();
+      return initializeProject(PackagingType.JAR);
    }
 
 }

--- a/test-harness/src/main/java/org/jboss/forge/test/SingletonAbstractShellTest.java
+++ b/test-harness/src/main/java/org/jboss/forge/test/SingletonAbstractShellTest.java
@@ -167,7 +167,7 @@ public abstract class SingletonAbstractShellTest
    {
       getShell().setCurrentResource(createTempFolder());
       queueInputLines("", "");
-      getShell().execute("new-project --named test --topLevelPackage com.test");
+      getShell().execute("new-project --named test --groupId com.test");
 
       Project project = getProject();
       tempFolder = project.getProjectRoot();


### PR DESCRIPTION
Changed NewProjectPlugin to support War and Pom project types.  --topLevelProject is now --groupId since groupId makes more sense for all projects.  I decided against having separate attributes for groupId and topLevelProject because the underlying code treated them the same resulting is issues when the two values were different; rather than refactoring that code and necessarily complicating things, I thought it best to simply use groupId.
