### PR TITLE
Fix NullPointerException in maven based source-install.

### DIFF
--- a/project-model-maven/src/main/java/org/jboss/forge/maven/facets/MavenPackagingFacet.java
+++ b/project-model-maven/src/main/java/org/jboss/forge/maven/facets/MavenPackagingFacet.java
@@ -152,7 +152,7 @@ public class MavenPackagingFacet extends BaseFacet implements PackagingFacet, Fa
          selected = list.toArray(new String[list.size()]);
       }
 
-      boolean success = project.getFacet(MavenCoreFacet.class).executeMaven(selected);
+      boolean success = project.getFacet(MavenCoreFacet.class).executeMaven(shell, selected);
 
       if (success)
       {


### PR DESCRIPTION
Fix NullPointerException in maven based source-install. A Null OutputWriter is passed to the Maven builder, use the Injected Shell
