### PR TITLE
Fixed Windows build

### DIFF
--- a/shell-api/src/main/java/org/jboss/forge/shell/util/Packages.java
+++ b/shell-api/src/main/java/org/jboss/forge/shell/util/Packages.java
@@ -22,8 +22,6 @@
 
 package org.jboss.forge.shell.util;
 
-import java.io.File;
-
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * 
@@ -39,13 +37,12 @@ public class Packages
     */
    public static String toFileSyntax(String pkg)
    {
-      return pkg.replace(".", File.separator);
+      return pkg.replace(".", "/");
    }
 
    public static String fromFileSyntax(String pkg)
    {
-
-      return pkg.replace(File.separator, ".");
+      return pkg.replace("/", ".");
    }
 
 }

--- a/test-harness/src/main/java/org/jboss/forge/test/QueuedInputStream.java
+++ b/test-harness/src/main/java/org/jboss/forge/test/QueuedInputStream.java
@@ -84,7 +84,6 @@ public class QueuedInputStream extends InputStream
             if (!inputQueue.isEmpty())
             {
                String line = inputQueue.remove();
-               System.out.println();
                byte[] bytes = new byte[] {};
 
                if (line != null)


### PR DESCRIPTION
The File.separator is not valid on windows, since the package path if formed with "/". 

There is no problem on treating files with "/" as the file separator
