### PR TITLE
Added bundle as a packaging type to better support OSGI bundles.

### DIFF
--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/CDIFacetImpl.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/CDIFacetImpl.java
@@ -94,7 +94,7 @@ public class CDIFacetImpl extends BaseFacet implements CDIFacet
       }
       else
       {
-         if (!PackagingType.JAR.equals(type))
+         if (!PackagingType.JAR.equals(type) && !PackagingType.BUNDLE.equals(type))
          {
             printPackTypeWarning(project, type);
          }
@@ -151,7 +151,7 @@ public class CDIFacetImpl extends BaseFacet implements CDIFacet
       if (!isInstalled())
       {
          PackagingType type = project.getFacet(PackagingFacet.class).getPackagingType();
-         if (!PackagingType.JAR.equals(type) && !PackagingType.WAR.equals(type))
+         if (!PackagingType.JAR.equals(type) && !PackagingType.WAR.equals(type) && !PackagingType.BUNDLE.equals(type))
          {
             printPackTypeWarning(project, type);
          }

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/PersistenceFacetImpl.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/PersistenceFacetImpl.java
@@ -53,7 +53,7 @@ import org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceDescr
  */
 @Alias("forge.spec.jpa")
 @RequiresFacet({ JavaSourceFacet.class, ResourceFacet.class, DependencyFacet.class })
-@RequiresPackagingType({ PackagingType.JAR, PackagingType.WAR })
+@RequiresPackagingType({ PackagingType.JAR, PackagingType.WAR, PackagingType.BUNDLE })
 public class PersistenceFacetImpl extends BaseFacet implements PersistenceFacet
 {
    private static final Dependency dep =

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/ServletFacetImpl.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/ServletFacetImpl.java
@@ -48,7 +48,7 @@ import org.jboss.shrinkwrap.descriptor.api.spec.servlet.web.WebAppDescriptor;
  */
 @Alias("forge.spec.servlet")
 @RequiresFacet({ MetadataFacet.class, WebResourceFacet.class, DependencyFacet.class })
-@RequiresPackagingType(PackagingType.WAR)
+@RequiresPackagingType({PackagingType.WAR, PackagingType.BUNDLE})
 public class ServletFacetImpl extends BaseFacet implements ServletFacet
 {
 

--- a/shell-api/src/main/java/org/jboss/forge/project/packaging/PackagingType.java
+++ b/shell-api/src/main/java/org/jboss/forge/project/packaging/PackagingType.java
@@ -32,6 +32,7 @@ public enum PackagingType
    BASIC("pom", "Basic Project"),
    JAR("jar", "Java Application"),
    WAR("war", "Java Web Application"),
+   BUNDLE("bundle", "OSGI Bundle Project"),
    OTHER("", "Other packaging type");
 
    private String type;

--- a/shell/src/main/java/org/jboss/forge/shell/plugins/builtin/NewProjectPackagingTypeCompleter.java
+++ b/shell/src/main/java/org/jboss/forge/shell/plugins/builtin/NewProjectPackagingTypeCompleter.java
@@ -10,6 +10,6 @@ public class NewProjectPackagingTypeCompleter extends SimpleTokenCompleter
    @Override
    public Iterable<?> getCompletionTokens()
    {
-      return Arrays.asList(PackagingType.BASIC, PackagingType.JAR, PackagingType.WAR);
+      return Arrays.asList(PackagingType.BASIC, PackagingType.JAR, PackagingType.WAR, PackagingType.BUNDLE);
    }
 }

--- a/shell/src/main/java/org/jboss/forge/shell/plugins/builtin/NewProjectPlugin.java
+++ b/shell/src/main/java/org/jboss/forge/shell/plugins/builtin/NewProjectPlugin.java
@@ -204,7 +204,7 @@ public class NewProjectPlugin implements Plugin
 
       Project project = null;
 
-      if (type.equals(PackagingType.JAR))
+      if (type.equals(PackagingType.JAR) || type.equals(PackagingType.BUNDLE))
       {
          project = projectFactory.createProject(dir,
                   DependencyFacet.class,
@@ -277,6 +277,7 @@ public class NewProjectPlugin implements Plugin
       validTypes.add(PackagingType.BASIC);
       validTypes.add(PackagingType.JAR);
       validTypes.add(PackagingType.WAR);
+      validTypes.add(PackagingType.BUNDLE);
       return validTypes;
    }
 }


### PR DESCRIPTION
Added "bundle" as packaging type. This is required to use the Maven Bundle Plugin which is common to use for building OSGI bundles: http://felix.apache.org/site/apache-felix-maven-bundle-plugin-bnd.html.

This is also required to continue work on the plugin-osgi: https://github.com/forge/plugin-osgi.

I added bundle as a valid packaging type everywhere it would make sense.
