### PR TITLE
Use parent.groupId as a fallback

### DIFF
--- a/project-model-maven/src/main/java/org/jboss/forge/maven/facets/MavenMetadataFacet.java
+++ b/project-model-maven/src/main/java/org/jboss/forge/maven/facets/MavenMetadataFacet.java
@@ -101,7 +101,12 @@ public class MavenMetadataFacet extends BaseFacet implements MetadataFacet
    @Override
    public String getTopLevelPackage()
    {
-      return project.getFacet(MavenCoreFacet.class).getPOM().getGroupId();
+	  String groupId = project.getFacet(MavenCoreFacet.class).getPOM().getGroupId();
+	  
+	  if (groupId == null) {
+		  groupId = project.getFacet(MavenCoreFacet.class).getPOM().getParent().getGroupId();
+	  }
+      return groupId;
    }
 
    @Override


### PR DESCRIPTION
The project's groupId may be set by its parent, rather than explicitly defined.   If groupId is null, try setting the project's groupId to that of its parent.
