### PR TITLE
Build command enhancements

### DIFF
--- a/shell/src/main/java/org/jboss/forge/shell/plugins/builtin/project/BuildPlugin.java
+++ b/shell/src/main/java/org/jboss/forge/shell/plugins/builtin/project/BuildPlugin.java
@@ -24,6 +24,7 @@ package org.jboss.forge.shell.plugins.builtin.project;
 
 import javax.inject.Inject;
 
+import org.jboss.forge.maven.profiles.Profile;
 import org.jboss.forge.project.Project;
 import org.jboss.forge.project.facets.DependencyFacet;
 import org.jboss.forge.project.facets.PackagingFacet;
@@ -64,6 +65,7 @@ public class BuildPlugin implements Plugin {
     @DefaultCommand
     public void build(final PipeOut out,
                       @Option(name = "notest", flagOnly = true) boolean notest,
+                      @Option(name = "profile", completer = ProfileCompleter.class) String profile,
                       @Option(description = "build arguments") String... args) {
         PackagingFacet packaging = project.getFacet(PackagingFacet.class);
 
@@ -77,6 +79,10 @@ public class BuildPlugin implements Plugin {
 
         if (notest) {
            arguments.add("-Dmaven.test.skip=true");
+        }
+
+        if(profile != null) {
+            arguments.add("-P" + profile);
         }
 
         if(args == null) {

--- a/shell/src/main/java/org/jboss/forge/shell/plugins/builtin/project/ProfileCompleter.java
+++ b/shell/src/main/java/org/jboss/forge/shell/plugins/builtin/project/ProfileCompleter.java
@@ -1,0 +1,33 @@
+package org.jboss.forge.shell.plugins.builtin.project;
+
+import org.apache.maven.model.Profile;
+import org.jboss.forge.maven.MavenCoreFacet;
+import org.jboss.forge.project.Project;
+import org.jboss.forge.shell.completer.SimpleTokenCompleter;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @Author Paul Bakker - paul.bakker.nl@gmail.com
+ */
+public class ProfileCompleter extends SimpleTokenCompleter {
+
+    @Inject
+    private Project project;
+
+    @Override
+    public List<String> getCompletionTokens()
+    {
+        MavenCoreFacet mavenCoreFacet = project.getFacet(MavenCoreFacet.class);
+        List<String> profiles = new ArrayList<String>();
+        List<Profile> profileList = mavenCoreFacet.getPOM().getProfiles();
+        for (Profile profile : profileList)
+        {
+            profiles.add(profile.getId());
+        }
+
+        return profiles;
+    }
+}


### PR DESCRIPTION
Added two options to the build command
--notest Adds the -Dmaven.test.skip=true parameter for faster builds.
--profile Lists the configured maven profiles and adds it using the -Pprofilename parameter. Required when using Arquillian since it's profile based.
