### PR TITLE
Resolve javac compile problem

### DIFF
--- a/scaffold-faces/src/main/java/org/jboss/forge/scaffold/faces/metawidget/widgetprocessor/UnsearchableWidgetProcessor.java
+++ b/scaffold-faces/src/main/java/org/jboss/forge/scaffold/faces/metawidget/widgetprocessor/UnsearchableWidgetProcessor.java
@@ -59,7 +59,7 @@ public class UnsearchableWidgetProcessor
    public StaticWidget processWidget(StaticWidget widget, String elementName, Map<String, String> attributes,
             StaticMetawidget metawidget)
    {
-      int widgetsProcessed = metawidget.getClientProperty(UnsearchableWidgetProcessor.class);
+      Integer widgetsProcessed = metawidget.getClientProperty(UnsearchableWidgetProcessor.class);
 
       // Ignore stubs
 


### PR DESCRIPTION
UnsearchableWidgetProcessor.java:[62,57] type parameters of <T>T cannot be determined; no unique maximal instance exists for type variable T with upper bounds int,java.lang.Object
