### PR TITLE
Fix compilation issue 

### DIFF
--- a/shell-api/src/main/java/org/jboss/forge/resources/AbstractResource.java
+++ b/shell-api/src/main/java/org/jboss/forge/resources/AbstractResource.java
@@ -121,7 +121,7 @@ public abstract class AbstractResource<T> implements Resource<T>
    protected abstract List<Resource<?>> doListResources();
 
    @Override
-   public final synchronized List<Resource<?>> listResources() {
+   public synchronized List<Resource<?>> listResources() {
        List<Resource<?>> resources = doListResources();
 
        Collections.sort(resources, new FQNResourceComparator());
@@ -129,7 +129,7 @@ public abstract class AbstractResource<T> implements Resource<T>
    }
 
    @Override
-   public final synchronized List<Resource<?>> listResources(final ResourceFilter filter)
+   public synchronized List<Resource<?>> listResources(final ResourceFilter filter)
    {
       List<Resource<?>> result = new ArrayList<Resource<?>>();
       for (Resource<?> resource : doListResources())

--- a/shell-api/src/main/java/org/jboss/forge/resources/enumtype/EnumConstantResource.java
+++ b/shell-api/src/main/java/org/jboss/forge/resources/enumtype/EnumConstantResource.java
@@ -27,7 +27,7 @@ public class EnumConstantResource extends VirtualResource<EnumConstant<JavaEnum>
    }
 
    @Override
-   public List<Resource<?>> listResources()
+   protected List<Resource<?>> doListResources()
    {
       return Collections.emptyList();
    }


### PR DESCRIPTION
Fix compilation issue caused by pull #112 not updating classes added in pull #110
- renamed EnumConstantResource.listResources() to doListResources()
- removed 'final' modifier for default implementations of listResources(*) to ensure that other plugins won't have the same issue
