### PR TITLE
FORGE-489: specify -pluginDir argument while starting forge

### DIFF
--- a/dist/src/main/resources/bin/forge
+++ b/dist/src/main/resources/bin/forge
@@ -29,9 +29,19 @@
 #   FORGE_OPTS - parameters passed to the Java VM when running Forge
 # -----------------------------------------------------------------------
 
+PLUGIN_DIR=""
+
 QUOTED_ARGS=""
 while [ "$1" != "" ] ; do
 
+  if [ "$PLUGIN_DIR" == "-pluginDir" ] ; then
+    PLUGIN_DIR="$1"
+  fi
+
+  if [ "$1" == "-pluginDir" ] ; then
+    PLUGIN_DIR="-pluginDir"
+  fi
+  
   QUOTED_ARGS="$QUOTED_ARGS \"$1\""
   shift
 
@@ -158,6 +168,6 @@ if $cygwin; then
     HOME=`cygpath --path --windows "$HOME"`
 fi
 
-forge_exec_cmd="\"$JAVACMD\" $FORGE_OPTS \"-Dforge.home=${FORGE_HOME}\"  \"-Dforge.shell.colorEnabled=true\" -jar \"${FORGE_HOME}/jboss-modules.jar\" -modulepath \"${FORGE_HOME}/modules:${HOME}/.forge/plugins\" org.jboss.forge"
+forge_exec_cmd="\"$JAVACMD\" $FORGE_OPTS \"-Dforge.home=${FORGE_HOME}\"  \"-Dforge.shell.colorEnabled=true\" -jar \"${FORGE_HOME}/jboss-modules.jar\" -modulepath \"${FORGE_HOME}/modules:${HOME}/.forge/plugins\:$PLUGIN_DIR" org.jboss.forge"
 
 eval $forge_exec_cmd "$QUOTED_ARGS"

--- a/dist/src/main/resources/bin/forge.bat
+++ b/dist/src/main/resources/bin/forge.bat
@@ -111,41 +111,20 @@ echo.
 goto error
 @REM ==== END VALIDATION ====
 
+@REM Initializing the argument line and the plugin directory if any
 :init
-@REM Decide how to startup depending on the version of windows
-
-@REM -- Windows NT with Novell Login
-if "%OS%"=="WINNT" goto WinNTNovell
-
-@REM -- Win98ME
-if NOT "%OS%"=="Windows_NT" goto Win9xArg
-
-:WinNTNovell
-
-@REM -- 4NT shell
-if "%@eval[2+2]" == "4" goto 4NTArgs
-
-@REM -- Regular WinNT shell
-set FORGE_CMD_LINE_ARGS=%*
-goto endInit
-
-@REM The 4NT Shell from jp software
-:4NTArgs
-set FORGE_CMD_LINE_ARGS=%$
-goto endInit
-
-:Win9xArg
-@REM Slurp the command line arguments.  This loop allows for an unlimited number
-@REM of agruments (up to the command line limit, anyway).
 set FORGE_CMD_LINE_ARGS=
-:Win9xApp
+set FORGE_PLUGIN_DIR=
+:initArgs
 if %1a==a goto endInit
 set FORGE_CMD_LINE_ARGS=%FORGE_CMD_LINE_ARGS% %1
+if "%FORGE_PLUGIN_DIR%"=="-pluginDir" set FORGE_PLUGIN_DIR=%1
+if "%1"=="-pluginDir" set FORGE_PLUGIN_DIR=%1
 shift
-goto Win9xApp
-
+goto initArgs
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
+
 SET FORGE_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 
 @REM -- 4NT shell
@@ -157,7 +136,7 @@ goto runForge
 @REM Start Forge
 :runForge
 set FORGE_MAIN_CLASS=org.jboss.forge.shell.Bootstrap
-%FORGE_JAVA_EXE% %FORGE_OPTS% "-Dforge.home=%FORGE_HOME%" -Dforge.shell.colorEnabled=true -jar %JBOSS_MODULES% -modulepath "%FORGE_HOME%\modules;%USERHOME%\.forge\plugins" org.jboss.forge %FORGE_CMD_LINE_ARGS%
+%FORGE_JAVA_EXE% %FORGE_OPTS% "-Dforge.home=%FORGE_HOME%" -Dforge.shell.colorEnabled=true -jar %JBOSS_MODULES% -modulepath "%FORGE_HOME%\modules;%USERHOME%\.forge\plugins;%FORGE_PLUGIN_DIR%" org.jboss.forge %FORGE_CMD_LINE_ARGS%
 if ERRORLEVEL 1 goto error
 goto end
 

--- a/shell/src/main/java/org/jboss/forge/shell/Bootstrap.java
+++ b/shell/src/main/java/org/jboss/forge/shell/Bootstrap.java
@@ -50,9 +50,14 @@ import org.jboss.weld.environment.se.WeldContainer;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * @author Mike Brock
  * @author Ronald van Kuijk
+ * @author <a href="mailto:koen.aers@gmail.com">Koen Aers</a>
  */
 public class Bootstrap
 {
+   
+   public static final String PROP_PLUGIN_DIR = "org.jboss.forge.pluginDir";
+   private static final String ARG_PLUGIN_DIR = "-pluginDir";
+   
    private static boolean pluginSystemEnabled = !Boolean.getBoolean("forge.plugins.disable");
    private static Thread currentShell = null;
    private static boolean restartRequested = false;
@@ -65,7 +70,21 @@ public class Bootstrap
    public static void main(final String[] args)
    {
       mainClassLoader = Thread.currentThread().getContextClassLoader();
+      readArguments(args);
       init();
+   }
+   
+   private static void readArguments(String[] args) {
+      readPluginDirArgument(args);
+   }
+   
+   private static void readPluginDirArgument(String[] args) {
+      for (int i = 0; i < args.length; i++) {
+         if (ARG_PLUGIN_DIR.equals(args[i]) && i + 1 < args.length) {
+            System.setProperty(PROP_PLUGIN_DIR, args[i + 1]);
+            return;
+         }
+      }
    }
 
    private static void init()
@@ -159,6 +178,7 @@ public class Bootstrap
 
    synchronized private static void loadPlugins()
    {
+      
       if (!pluginSystemEnabled)
          return;
 

--- a/shell/src/main/java/org/jboss/forge/shell/ForgeEnvironmentImpl.java
+++ b/shell/src/main/java/org/jboss/forge/shell/ForgeEnvironmentImpl.java
@@ -60,8 +60,11 @@ public class ForgeEnvironmentImpl implements ForgeEnvironment
    @Override
    public DirectoryResource getPluginDirectory()
    {
-      String pluginPath = getProperty(ShellImpl.PROP_FORGE_CONFIG_DIR) + "plugins/";
-      FileResource<?> resource = (FileResource<?>) resourceFactory.getResourceFrom(new File(pluginPath));
+      String pluginDir = System.getProperty(Bootstrap.PROP_PLUGIN_DIR);
+      if (pluginDir == null) {
+         pluginDir = getProperty(ShellImpl.PROP_FORGE_CONFIG_DIR) + "plugins/";
+      }
+      FileResource<?> resource = (FileResource<?>) resourceFactory.getResourceFrom(new File(pluginDir));
       if (!resource.exists())
       {
          resource.mkdirs();

--- a/shell/src/main/java/org/jboss/forge/shell/InstalledPluginRegistry.java
+++ b/shell/src/main/java/org/jboss/forge/shell/InstalledPluginRegistry.java
@@ -42,6 +42,7 @@ import org.jboss.forge.shell.util.Streams;
  * Used to perform {@link Plugin} installation/registration operations.
  * 
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * @author <a href="mailto:koen.aers@gmail.com">Koen Aers</a>
  */
 public class InstalledPluginRegistry
 {
@@ -49,11 +50,32 @@ public class InstalledPluginRegistry
    private static final String ATTR_SLOT = "slot";
    private static final String ATTR_API_VERSION = "api-version";
    private static final String ATTR_NAME = "name";
-   private static final String REGISTRY = "/.forge/plugins/installed.xml";
+   private static final String PLUGIN_DIR_DEFAULT = "/.forge/plugins";
+   private static final String REGISTRY_FILE = "/installed.xml";
+
+   private static String PLUGIN_DIR = null;
+   private static String REGISTRY = null;
+      
+   private static String getPluginDir() {
+      if (PLUGIN_DIR == null) {
+         PLUGIN_DIR = System.getProperty(Bootstrap.PROP_PLUGIN_DIR);
+         if (PLUGIN_DIR == null) {
+            PLUGIN_DIR = OSUtils.getUserHomePath() + PLUGIN_DIR_DEFAULT;
+         }
+      }
+      return PLUGIN_DIR;
+   }
+   
+   private static String getRegistry() {
+      if (REGISTRY == null) {
+         REGISTRY = getPluginDir() + REGISTRY_FILE;
+      }
+      return REGISTRY;
+   }
 
    public static File getRegistryFile()
    {
-      return new File(REGISTRY);
+      return new File(getRegistry());
    }
 
    public static List<PluginEntry> listByVersion(final String version)
@@ -78,7 +100,8 @@ public class InstalledPluginRegistry
    public static List<PluginEntry> list()
    {
       List<PluginEntry> result = new ArrayList<PluginEntry>();
-      File registryFile = new File(OSUtils.getUserHomePath() + REGISTRY);
+//      File registryFile = new File(OSUtils.getUserHomePath() + getRegistry());
+      File registryFile = getRegistryFile();
       try {
          Node installed = XMLParser.parse(new FileInputStream(registryFile));
          List<Node> list = installed.get("plugin");
@@ -114,7 +137,8 @@ public class InstalledPluginRegistry
       }
 
       Node installed = null;
-      File registryFile = new File(OSUtils.getUserHomePath() + REGISTRY);
+//      File registryFile = new File(OSUtils.getUserHomePath() + getRegistry());
+      File registryFile = getRegistryFile();
       try {
 
          if (registryFile.exists())
@@ -153,7 +177,8 @@ public class InstalledPluginRegistry
          throw new RuntimeException("Plugin must not be null");
       }
 
-      File registryFile = new File(OSUtils.getUserHomePath() + REGISTRY);
+//      File registryFile = new File(OSUtils.getUserHomePath() + getRegistry());
+      File registryFile = getRegistryFile();
       if (registryFile.exists())
       {
          try {
@@ -177,7 +202,8 @@ public class InstalledPluginRegistry
          throw new RuntimeException("Plugin must not be null");
       }
 
-      File registryFile = new File(OSUtils.getUserHomePath() + REGISTRY);
+//      File registryFile = new File(OSUtils.getUserHomePath() + getRegistry());
+      File registryFile = getRegistryFile();
       if (registryFile.exists())
       {
          try {


### PR DESCRIPTION
'forge -pluginDir path/to/dir' will make sure forge looks in the specified folder for plugins and installs new ones also in that folder; not specifying the argument makes forge default to .forge/plugins.
