### PR TITLE
Making sure to use the latest version of forge-shell-api

### DIFF
--- a/project-model-maven-tests/src/test/java/org/jboss/forge/maven/facets/MavenDependencyFacetTest.java
+++ b/project-model-maven-tests/src/test/java/org/jboss/forge/maven/facets/MavenDependencyFacetTest.java
@@ -22,10 +22,6 @@
 
 package org.jboss.forge.maven.facets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -39,6 +35,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
@@ -180,7 +180,7 @@ public class MavenDependencyFacetTest extends ProjectModelTest
    {
       DependencyFacet dependencyFacet = getProject().getFacet(DependencyFacet.class);
       DependencyBuilder forgeShellApiDependency = DependencyBuilder.create().setGroupId("org.jboss.forge")
-               .setArtifactId("forge-shell-api").setVersion("1.0.0-SNAPSHOT");
+               .setArtifactId("forge-shell-api").setVersion("[1.0.0-SNAPSHOT,)");
       DependencyBuilder cdiDependency = DependencyBuilder.create().setGroupId("javax.enterprise")
                .setArtifactId("cdi-api");
       assertFalse(dependencyFacet.hasEffectiveDependency(cdiDependency));


### PR DESCRIPTION
This should use the latest version in the repo for forge-shell-api, which should be the version being built. This way there will always be a version that should work.
