### PR TITLE
Classifiers not considered correctly in dependency resolution

### DIFF
--- a/maven-api/src/main/java/org/jboss/forge/maven/dependencies/MavenDependencyAdapter.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/dependencies/MavenDependencyAdapter.java
@@ -50,7 +50,7 @@ public class MavenDependencyAdapter extends org.apache.maven.model.Dependency im
 
       this.setArtifactId(clone.getArtifactId());
       this.setGroupId(clone.getGroupId());
-      this.setClassifier(clone.getClassifier());
+      this.setClassifier("".equals(clone.getClassifier()) ? null : clone.getClassifier());
       this.setExclusions(clone.getExclusions());
       this.setOptional(clone.isOptional());
       this.setScope(clone.getScope());
@@ -70,6 +70,7 @@ public class MavenDependencyAdapter extends org.apache.maven.model.Dependency im
       this.setVersion(dep.getVersion());
       this.setScope(dep.getScopeType());
       this.setType(dep.getPackagingType());
+      this.setClassifier(dep.getClassifier());
 
       for (Dependency exclusion : dep.getExcludedDependencies())
       {
@@ -89,7 +90,7 @@ public class MavenDependencyAdapter extends org.apache.maven.model.Dependency im
 
       this.setArtifactId(dep.getArtifact().getArtifactId());
       this.setGroupId(dep.getArtifact().getGroupId());
-      this.setClassifier(dep.getArtifact().getClassifier());
+      this.setClassifier("".equals(dep.getArtifact().getClassifier()) ? null : dep.getArtifact().getClassifier());
       this.setExclusions(dep.getExclusions());
       this.setOptional(dep.isOptional());
       this.setScope(dep.getScope());

--- a/shell-api/src/main/java/org/jboss/forge/project/dependencies/DependencyBuilder.java
+++ b/shell-api/src/main/java/org/jboss/forge/project/dependencies/DependencyBuilder.java
@@ -78,7 +78,8 @@ public class DependencyBuilder implements Dependency
       }
 
       return !(l.getArtifactId() != null ? !l.getArtifactId().equals(r.getArtifactId()) : r.getArtifactId() != null) &&
-               !(l.getGroupId() != null ? !l.getGroupId().equals(r.getGroupId()) : r.getGroupId() != null);
+               !(l.getGroupId() != null ? !l.getGroupId().equals(r.getGroupId()) : r.getGroupId() != null) && 
+               !(l.getClassifier() != null ? !l.getClassifier().equals(r.getClassifier()) : r.getClassifier() != null);
 
    }
 


### PR DESCRIPTION
Added consideration of classifiers. With this change its possible add the same artifact with different classifiers. This is very important for GWT applications because they need a class and a source jar to compile. Without that, the dependency is always overridden and the classifier is ignored.
