### PR TITLE
Format the Java sources upon file creation

### DIFF
--- a/javaee-impl/src/test/java/org/jboss/forge/spec/jpa/NewEntityPluginTest.java
+++ b/javaee-impl/src/test/java/org/jboss/forge/spec/jpa/NewEntityPluginTest.java
@@ -119,4 +119,16 @@ public class NewEntityPluginTest extends AbstractJPATest
 
       assertEquals(entitySource.getPackage(), pkgName);
    }
+   
+   @Test
+   public void assertEntityClassDeclarationOnNewLine() throws Exception
+   {
+       Project project = getProject();
+       JavaClass javaClass = generateEntity(project);
+       
+       String content = javaClass.toString();
+       
+       assertTrue(content.contains("@Entity" + System.getProperty("line.separator") + 
+               "public class"));
+   }
 }

--- a/parser-java/src/main/java/org/jboss/forge/parser/java/impl/AbstractJavaSource.java
+++ b/parser-java/src/main/java/org/jboss/forge/parser/java/impl/AbstractJavaSource.java
@@ -52,6 +52,7 @@ import org.jboss.forge.parser.java.Visibility;
 import org.jboss.forge.parser.java.ast.AnnotationAccessor;
 import org.jboss.forge.parser.java.ast.ModifierAccessor;
 import org.jboss.forge.parser.java.ast.TypeDeclarationFinderVisitor;
+import org.jboss.forge.parser.java.util.Formatter;
 import org.jboss.forge.parser.java.util.Strings;
 import org.jboss.forge.parser.java.util.Types;
 import org.jboss.forge.parser.spi.WildcardImportResolver;
@@ -592,18 +593,8 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
       catch (Exception e) {
          throw new ParserException("Could not modify source: " + unit.toString(), e);
       }
-
-      String documentString = document.get();
-      return ensureCorrectNewLines(documentString);
-   }
-
-   private String ensureCorrectNewLines(String documentString) {
-       String newLine = System.getProperty("line.separator");
-       
-       if (documentString.indexOf("\n") != -1 && documentString.indexOf(newLine) == -1)       
-           return documentString.replaceAll("\n", newLine);
-       
-       return documentString;
+      
+      return Formatter.format(document.get());
    }
 
    @Override

--- a/parser-java/src/main/java/org/jboss/forge/parser/java/util/Formatter.java
+++ b/parser-java/src/main/java/org/jboss/forge/parser/java/util/Formatter.java
@@ -41,19 +41,20 @@ public abstract class Formatter
 {
    public static String format(JavaClass javaClass)
    {
-      // TODO locate user's eclipse project settings, use those if we can.
-      Properties options = readConfig("org.eclipse.jdt.core.prefs");
+      return format(javaClass.toString());
+   }
+   
+   public static String format(String source)
+   {
+       // TODO locate user's eclipse project settings, use those if we can.
+       Properties options = readConfig("org.eclipse.jdt.core.prefs");
 
-      final CodeFormatter codeFormatter = ToolFactory.createCodeFormatter(options);
-      String result = formatFile(javaClass, codeFormatter);
-
-      return result;
+       final CodeFormatter codeFormatter = ToolFactory.createCodeFormatter(options);
+       return ensureCorrectNewLines(formatFile(source, codeFormatter));
    }
 
-   private static String formatFile(JavaClass javaClass, CodeFormatter codeFormatter)
+   private static String formatFile(String contents, CodeFormatter codeFormatter)
    {
-      String contents = javaClass.toString();
-
       IDocument doc = new Document(contents);
       try
       {
@@ -104,4 +105,16 @@ public abstract class Formatter
          }
       }
    }
+   
+   
+   private static String ensureCorrectNewLines(String documentString) 
+   {
+       String newLine = System.getProperty("line.separator");
+       
+       if (documentString.indexOf("\n") != -1 && documentString.indexOf(newLine) == -1)       
+           return documentString.replaceAll("\n", newLine);
+       
+       return documentString;
+   }
+
 }

--- a/parser-java/src/test/java/org/jboss/forge/test/parser/java/common/AnnotationTest.java
+++ b/parser-java/src/test/java/org/jboss/forge/test/parser/java/common/AnnotationTest.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.jboss.forge.parser.java.Annotation;
 import org.jboss.forge.parser.java.AnnotationTarget;
@@ -119,8 +121,9 @@ public abstract class AnnotationTest<O extends JavaSource<O>, T>
       assertEquals(size + 2, annotations.size());
       assertEquals(Test.class.getSimpleName(), anno1.getName());
       assertEquals(Test.class.getSimpleName(), anno2.getName());
-      String pattern = "@" + Test.class.getSimpleName() + " " + "@" + Test.class.getSimpleName();
-      assertTrue(target.toString().contains(pattern));
+      Pattern pattern = Pattern.compile("@" + Test.class.getSimpleName() + "\\s*" + "@" + Test.class.getSimpleName());
+      Matcher matcher = pattern.matcher(target.toString());
+      assertTrue(matcher.find());
       assertTrue(target.getOrigin().hasImport(Test.class));
    }
 


### PR DESCRIPTION
All the formatting code is moved to the Formatter class. The AbstractJavaSource just uses it.

Tested on 64-bit Windows 7. parser-java and javaee-impl also tested on Ubuntu
