### PR TITLE
accept difference in Java formatter configurations

### DIFF
--- a/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/AbstractFacesScaffoldTest.java
+++ b/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/AbstractFacesScaffoldTest.java
@@ -53,4 +53,12 @@ public abstract class AbstractFacesScaffoldTest extends AbstractShellTest
       getShell().execute("scaffold setup --targetDir " + targetDir);
       return project;
    }
+   
+   protected String normalized(StringBuilder sb) {
+      return normalized(sb.toString());
+   }
+   
+   protected String normalized(String input) {
+      return input.replaceAll("(\r|\n|\\s)+"," ");
+   }
 }

--- a/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/FacesScaffoldTest.java
+++ b/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/FacesScaffoldTest.java
@@ -255,26 +255,26 @@ public class FacesScaffoldTest extends AbstractFacesScaffoldTest
       Assert.assertTrue(customerBean.exists());
       contents = Streams.toString(customerBean.getResourceInputStream());
 
-      Assert.assertTrue(contents.contains("\tprivate Customer customer;"));
+      Assert.assertTrue(contents.contains("  private Customer customer;"));
 
       StringBuilder qbeMetawidget = new StringBuilder();
-      qbeMetawidget.append("\t\t"  ).append("List<Predicate> predicatesList = new ArrayList<Predicate>();"                               ).append(crlf);
-      qbeMetawidget.append(""      ).append(""                                                                                           ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("String firstName = this.search.getFirstName();"                                             ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("if (firstName != null && !\"\".equals(firstName)) {"                                        ).append(crlf);
-      qbeMetawidget.append("\t\t\t").append(  "predicatesList.add(builder.like(root.<String>get(\"firstName\"), '%' + firstName + '%'));").append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("}"                                                                                          ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("String lastName = this.search.getLastName();"                                               ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("if (lastName != null && !\"\".equals(lastName)) {"                                          ).append(crlf);
-      qbeMetawidget.append("\t\t\t").append(  "predicatesList.add(builder.like(root.<String>get(\"lastName\"), '%' + lastName + '%'));"  ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("}"                                                                                          ).append(crlf);
-      qbeMetawidget.append(""      ).append(""                                                                                           ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("return "                                                                                    );
+      qbeMetawidget.append("      "   ).append("List<Predicate> predicatesList = new ArrayList<Predicate>();"                               ).append(crlf);
+      qbeMetawidget.append(""         ).append(""                                                                                           ).append(crlf);
+      qbeMetawidget.append("      "   ).append("String firstName = this.search.getFirstName();"                                             ).append(crlf);
+      qbeMetawidget.append("      "   ).append("if (firstName != null && !\"\".equals(firstName)) {"                                        ).append(crlf);
+      qbeMetawidget.append("         ").append(  "predicatesList.add(builder.like(root.<String> get(\"firstName\"), '%' + firstName + '%'));").append(crlf);
+      qbeMetawidget.append("      "   ).append("}"                                                                                          ).append(crlf);
+      qbeMetawidget.append("      "   ).append("String lastName = this.search.getLastName();"                                               ).append(crlf);
+      qbeMetawidget.append("      "   ).append("if (lastName != null && !\"\".equals(lastName)) {"                                          ).append(crlf);
+      qbeMetawidget.append("         ").append(  "predicatesList.add(builder.like(root.<String> get(\"lastName\"), '%' + lastName + '%'));"  ).append(crlf);
+      qbeMetawidget.append("      "   ).append("}"                                                                                          ).append(crlf);
+      qbeMetawidget.append(""         ).append(""                                                                                           ).append(crlf);
+      qbeMetawidget.append("      "   ).append("return "                                                                                    );
 
-      Assert.assertTrue(contents.contains(qbeMetawidget));
+      Assert.assertTrue(normalized(contents).contains(normalized(qbeMetawidget)));
 
-      Assert.assertTrue(contents.contains("\tprivate Customer add = new Customer();"));
-      Assert.assertTrue(contents.contains("\t\tthis.add = new Customer();"));
+      Assert.assertTrue(contents.contains("private Customer add = new Customer();"));
+      Assert.assertTrue(contents.contains("this.add = new Customer();"));
 
       // ViewUtils
 
@@ -705,17 +705,17 @@ public class FacesScaffoldTest extends AbstractFacesScaffoldTest
       contents = Streams.toString(customerBean.getResourceInputStream());
 
       StringBuilder qbeMetawidget = new StringBuilder();
-      qbeMetawidget.append("\t\t"  ).append("Employer employer = this.search.getEmployer();"                        ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("if (employer != null) {"                                               ).append(crlf);
-      qbeMetawidget.append("\t\t\t").append(  "predicatesList.add(builder.equal(root.get(\"employer\"), employer));").append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("}"                                                                     ).append(crlf);
+      qbeMetawidget.append("  "     ).append("Employer employer = this.search.getEmployer();"                      ).append(crlf);
+      qbeMetawidget.append("    "   ).append("if (employer != null) {"                                             ).append(crlf);
+      qbeMetawidget.append("       ").append("predicatesList.add(builder.equal(root.get(\"employer\"), employer));").append(crlf);
+      qbeMetawidget.append("    "   ).append("}"                                                                   ).append(crlf);
 
-      Assert.assertTrue(contents.contains(qbeMetawidget));
+      Assert.assertTrue(normalized(contents).contains(normalized(qbeMetawidget)));
       
       StringBuilder expectedContent = new StringBuilder();
       expectedContent.append("import com.test.model.Customer;").append(crlf);
       expectedContent.append("import com.test.model.Employer;").append(crlf);
-      Assert.assertTrue(contents.contains(expectedContent));
+      Assert.assertTrue(normalized(contents).contains(normalized(expectedContent)));
    }
 
    @Test
@@ -1229,30 +1229,30 @@ public class FacesScaffoldTest extends AbstractFacesScaffoldTest
       Assert.assertTrue(customerBean.exists());
       contents = Streams.toString(customerBean.getResourceInputStream());
 
-      Assert.assertTrue(contents.contains("\n\tprivate Customer customer;"));
+      Assert.assertTrue(contents.contains("private Customer customer;"));
 
       StringBuilder qbeMetawidget = new StringBuilder();
-      qbeMetawidget.append("\t\t"  ).append("List<Predicate> predicatesList = new ArrayList<Predicate>();"                               ).append(crlf);
-      qbeMetawidget.append(""      ).append(""                                                                                           ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("String firstName = this.search.getFirstName();"                                             ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("if (firstName != null && !\"\".equals(firstName)) {"                                        ).append(crlf);
-      qbeMetawidget.append("\t\t\t").append(  "predicatesList.add(builder.like(root.<String>get(\"firstName\"), '%' + firstName + '%'));").append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("}"                                                                                          ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("String lastName = this.search.getLastName();"                                               ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("if (lastName != null && !\"\".equals(lastName)) {"                                          ).append(crlf);
-      qbeMetawidget.append("\t\t\t").append(  "predicatesList.add(builder.like(root.<String>get(\"lastName\"), '%' + lastName + '%'));"  ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("}"                                                                                          ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("RatingEnum rating = this.search.getRating();"                                               ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("if (rating != null) {"                                                                      ).append(crlf);
-      qbeMetawidget.append("\t\t\t").append(  "predicatesList.add(builder.equal(root.get(\"rating\"), rating));"                         ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("}"                                                                                          ).append(crlf);
-      qbeMetawidget.append(""       ).append(""                                                                                          ).append(crlf);
-      qbeMetawidget.append("\t\t"  ).append("return ");
+      qbeMetawidget.append("      "   ).append("List<Predicate> predicatesList = new ArrayList<Predicate>();"                                ).append(crlf);
+      qbeMetawidget.append(""         ).append(""                                                                                            ).append(crlf);
+      qbeMetawidget.append("      "   ).append("String firstName = this.search.getFirstName();"                                              ).append(crlf);
+      qbeMetawidget.append("      "   ).append("if (firstName != null && !\"\".equals(firstName)) {"                                         ).append(crlf);
+      qbeMetawidget.append("         ").append(  "predicatesList.add(builder.like(root.<String> get(\"firstName\"), '%' + firstName + '%'));").append(crlf);
+      qbeMetawidget.append("      "   ).append("}"                                                                                           ).append(crlf);
+      qbeMetawidget.append("      "   ).append("String lastName = this.search.getLastName();"                                                ).append(crlf);
+      qbeMetawidget.append("      "   ).append("if (lastName != null && !\"\".equals(lastName)) {"                                           ).append(crlf);
+      qbeMetawidget.append("         ").append(  "predicatesList.add(builder.like(root.<String> get(\"lastName\"), '%' + lastName + '%'));"  ).append(crlf);
+      qbeMetawidget.append("      "   ).append("}"                                                                                           ).append(crlf);
+      qbeMetawidget.append("      "   ).append("RatingEnum rating = this.search.getRating();"                                                ).append(crlf);
+      qbeMetawidget.append("      "   ).append("if (rating != null) {"                                                                       ).append(crlf);
+      qbeMetawidget.append("         ").append(  "predicatesList.add(builder.equal(root.get(\"rating\"), rating));"                          ).append(crlf);
+      qbeMetawidget.append("      "   ).append("}"                                                                                           ).append(crlf);
+      qbeMetawidget.append(""         ).append(""                                                                                            ).append(crlf);
+      qbeMetawidget.append("      "   ).append("return ");
 
-      Assert.assertTrue(contents.contains(qbeMetawidget));
+      Assert.assertTrue(normalized(contents).contains(normalized(qbeMetawidget)));
 
-      Assert.assertTrue(contents.contains("\n\tprivate Customer add = new Customer();"));
-      Assert.assertTrue(contents.contains("\n\t\tthis.add = new Customer();"));
+      Assert.assertTrue(contents.contains("private Customer add = new Customer();"));
+      Assert.assertTrue(contents.contains("this.add = new Customer();"));
 
       // ViewUtils
 

--- a/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/scenario/FacesScaffoldScenarioTest.java
+++ b/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/scenario/FacesScaffoldScenarioTest.java
@@ -133,13 +133,13 @@ public class FacesScaffoldScenarioTest extends AbstractFacesScaffoldTest
       contents = Streams.toString(customerBean.getResourceInputStream());
 
       StringBuilder qbeMetawidget = new StringBuilder(
-               "      String City = this.search.getCity();\r\n");
-      qbeMetawidget.append("      if (City != null && !\"\".equals(City)) {\r\n");
+               "      String City = this.search.getCity();\n");
+      qbeMetawidget.append("      if (City != null && !\"\".equals(City)) {\n");
       qbeMetawidget
-               .append("         predicatesList.add(builder.like(root.<String>get(\"City\"), '%' + City + '%'));\r\n");
-      qbeMetawidget.append("      }\r\n");
+               .append("         predicatesList.add(builder.like(root.<String> get(\"City\"), '%' + City + '%'));\n");
+      qbeMetawidget.append("      }\n");
 
-      Assert.assertTrue(contents.contains(qbeMetawidget));
+      Assert.assertTrue(normalized(contents).contains(normalized(qbeMetawidget)));
       
       FileResource<?> welcomeFile = web.getWebResource("/index.html");
       Assert.assertTrue(welcomeFile.exists());

--- a/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/scenario/shopping/FacesScaffoldShoppingTest.java
+++ b/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/scenario/shopping/FacesScaffoldShoppingTest.java
@@ -145,13 +145,13 @@ public class FacesScaffoldShoppingTest extends AbstractFacesScaffoldTest
       contents = Streams.toString(customerBean.getResourceInputStream());
 
       StringBuilder qbeMetawidget = new StringBuilder(
-               "\t\tString City = this.search.getCity();\r\n");
-      qbeMetawidget.append("\t\tif (City != null && !\"\".equals(City)) {\r\n");
+               "      String City = this.search.getCity();\n");
+      qbeMetawidget.append("      if (City != null && !\"\".equals(City)) {\n");
       qbeMetawidget
-               .append("\t\t\tpredicatesList.add(builder.like(root.<String>get(\"City\"), '%' + City + '%'));\r\n");
-      qbeMetawidget.append("\t\t}\r\n");
+               .append("         predicatesList.add(builder.like(root.<String> get(\"City\"), '%' + City + '%'));\n");
+      qbeMetawidget.append("      }\n");
 
-      Assert.assertTrue(contents.contains(qbeMetawidget));
+      Assert.assertTrue(normalized(contents).contains(normalized(qbeMetawidget)));
 
       // Deploy to a real container and test
 


### PR DESCRIPTION
this fix makes the tests of the generated Java code unaware of indentation and positioning of code block braces by compressing white space (see: normalize())  

Results :
Tests run: 43, Failures: 0, Errors: 0, Skipped: 0
