### PR TITLE
FORGE-582

### DIFF
--- a/javaee-impl/src/test/java/org/jboss/forge/spec/jpa/NewEntityPluginTest.java
+++ b/javaee-impl/src/test/java/org/jboss/forge/spec/jpa/NewEntityPluginTest.java
@@ -74,6 +74,7 @@ public class NewEntityPluginTest extends AbstractJPATest
       assertTrue(javaClass.hasField("version"));
       assertEquals("0", javaClass.getField("version").getLiteralInitializer());
       assertEquals("null", javaClass.getField("id").getLiteralInitializer());
+      assertTrue(javaClass.toString().contains("implements Serializable"));
    }
 
    @Test

--- a/parser-java/src/main/java/org/jboss/forge/parser/java/impl/AbstractJavaSource.java
+++ b/parser-java/src/main/java/org/jboss/forge/parser/java/impl/AbstractJavaSource.java
@@ -721,9 +721,22 @@ public abstract class AbstractJavaSource<O extends JavaSource<O>> implements
    @Override
    public O addInterface(final String type)
    {
-      List<Type> interfaces = JDTHelper.getInterfaces(
-               JavaParser.parse(JavaInterfaceImpl.class, "public interface Mock extends " + type
-                        + " {}").getBodyDeclaration());
+      List<Type> interfaces = new ArrayList<Type>();
+
+      if (this.hasImport(Types.toSimpleName(type)))
+      {
+          if (this.hasInterface(type))
+          {
+              interfaces = JDTHelper.getInterfaces(JavaParser.parse(JavaInterfaceImpl.class, 
+                      "public interface Mock extends " + type + " {}").getBodyDeclaration());
+          }
+      }
+      else
+      {
+          interfaces = JDTHelper.getInterfaces(
+                  JavaParser.parse(JavaInterfaceImpl.class, "public interface Mock extends " + Types.toSimpleName(type)
+                           + " {}").getBodyDeclaration());
+      }
 
       if (!interfaces.isEmpty())
       {


### PR DESCRIPTION
Modify AbstractJavaSource.addInterface so warnings are not generated in JPA entity generation.

Enhance NewEntityPluginTest to check that a generated entity has "implements Serializable" not "implements java.io.Serializable"
