### PR TITLE
This line does not need to be here. It is just redoing work that were already done.

### DIFF
--- a/shell/src/main/java/org/jboss/forge/shell/ShellImpl.java
+++ b/shell/src/main/java/org/jboss/forge/shell/ShellImpl.java
@@ -1499,7 +1499,6 @@ public class ShellImpl extends AbstractShellPrompt implements Shell
          TerminalFactory.configure(TerminalFactory.Type.NONE);
          TerminalFactory.reset();
       }
-      initReaderAndStreams();
    }
 
    @Override


### PR DESCRIPTION
configureOSTerminal() is a private method called by two others methods init() and setAnsiSupported() both of them call initReaderAndStreams() just after calling configureOSTerminal(). So it removes the necessity of configureOSTerminal() to recall initReaderAndStreams() at the end of it, which will redo work that was already done, and will take more time at forge startup. 
