### PR TITLE
Improvements for a more restful rest plugin

### DIFF
--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/rest/RestPlugin.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/rest/RestPlugin.java
@@ -61,6 +61,7 @@ import org.jboss.seam.render.template.CompiledTemplateResource;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * @author <a href="mailto:sso@adorsys.de">Sandro Sonntag</a>
  */
 @Alias("rest")
 @RequiresFacet(RestFacet.class)
@@ -120,8 +121,8 @@ public class RestPlugin implements Plugin
    }
 
    @SuppressWarnings("unchecked")
-   @Command(value = "endpoint-from-entity", help = "Creates a REST endpoint from an existing domain @Entity object")
-   public void endpointFromEntity(
+   @Command(value = "endpoint-from-entity", help = "Creates a REST resource from an existing domain @Entity object")
+   public void endpointFromResource(
             final PipeOut out,
             @Option(name = "contentType", defaultValue = MediaType.APPLICATION_XML, completer = ContentTypeCompleter.class) String contentType,
             @Option(required = false) JavaResource[] targets)
@@ -159,10 +160,11 @@ public class RestPlugin implements Plugin
          if (!Types.isBasicType(idType))
          {
             ShellMessages.error(out, "Skipped class [" + entity.getQualifiedName() + "] because @Id type [" + idType
-                     + "] is not supported by endpoint generation.");
+                     + "] is not supported by resource generation.");
             continue;
          }
          String idSetterName = resolveIdSetterName(entity);
+         String idGetterName = resolveIdGetterName(entity);
 
          CompiledTemplateResource template = compiler.compileResource(getClass().getResourceAsStream(
                   "/org/jboss/forge/rest/Endpoint.jv"));
@@ -171,27 +173,29 @@ public class RestPlugin implements Plugin
          map.put("entity", entity);
          map.put("idType", idType);
          map.put("setIdStatement", idSetterName);
+         map.put("getIdStatement", idGetterName);
          map.put("contentType", contentType);
-         map.put("entityTable", getEntityTable(entity));
+         String entityTable = getEntityTable(entity);
+         map.put("entityTable", entityTable);
+         map.put("resourcePath", entityTable.toLowerCase() + "s");
 
-         JavaClass endpoint = JavaParser.parse(JavaClass.class, template.render(map));
-         endpoint.addImport(entity.getQualifiedName());
-         endpoint.setPackage(java.getBasePackage() + ".rest");
-         endpoint.getAnnotation(Path.class).setStringValue("/" + getEntityTable(entity).toLowerCase());
+         JavaClass resource = JavaParser.parse(JavaClass.class, template.render(map));
+         resource.addImport(entity.getQualifiedName());
+         resource.setPackage(java.getBasePackage() + ".rest");
 
          /*
           * Save the sources
           */
          java.saveJavaSource(entity);
 
-         if (!java.getJavaResource(endpoint).exists()
-                  || prompt.promptBoolean("Endpoint [" + endpoint.getQualifiedName() + "] already, exists. Overwrite?"))
+         if (!java.getJavaResource(resource).exists()
+                  || prompt.promptBoolean("Resource [" + resource.getQualifiedName() + "] already, exists. Overwrite?"))
          {
-            java.saveJavaSource(endpoint);
-            ShellMessages.success(out, "Generated REST endpoint for [" + entity.getQualifiedName() + "]");
+            java.saveJavaSource(resource);
+            ShellMessages.success(out, "Generated REST resource for [" + entity.getQualifiedName() + "]");
          }
          else
-            ShellMessages.info(out, "Aborted endpoint generation for [" + entity.getQualifiedName() + "]");
+            ShellMessages.info(out, "Aborted REST resource generation for [" + entity.getQualifiedName() + "]");
       }
    }
 
@@ -280,6 +284,74 @@ public class RestPlugin implements Plugin
       if (result == null)
       {
          throw new RuntimeException("Could not determine @Id field and setter method for @Entity ["
+                  + entity.getQualifiedName()
+                  + "]. Aborting.");
+      }
+
+      return result;
+   }
+   
+
+   private String resolveIdGetterName(JavaClass entity)
+   {
+      String result = null;
+
+      for (Member<JavaClass, ?> member : entity.getMembers())
+      {
+         if (member.hasAnnotation(Id.class))
+         {
+            String name = member.getName();
+            String type = null;
+            if (member instanceof Method)
+            {
+               type = ((Method<?>) member).getReturnType();
+               if (name.startsWith("get"))
+               {
+                  name = name.substring(2);
+               }
+            }
+            else if (member instanceof Field)
+            {
+               type = ((Field<?>) member).getType();
+            }
+
+            if (type != null)
+            {
+               for (Method<JavaClass> method : entity.getMethods())
+               {
+                  // It's a getter
+                  if (method.getParameters().size() == 0 && type.equals(method.getReturnType()))
+                  {
+                    if (method.getName().toLowerCase().contains(name.toLowerCase()))
+                    {
+                      result = method.getName() + "()";
+                      break;
+                    }
+                  }
+               }
+            }
+
+            if (result != null)
+            {
+               break;
+            }
+            else if (type != null && result == null && member.isPublic())
+            {
+               String memberName = member.getName();
+               // Cheat a little if the member is public
+               if (member instanceof Method && memberName.startsWith("get"))
+               {
+                  memberName = memberName.substring(3);
+                  memberName = Strings.uncapitalize(memberName);
+               }
+               result = memberName;
+            }
+         }
+      }
+
+      if (result == null)
+      {
+         throw new RuntimeException("Could not determine @Id field and getter method for @Entity ["
                   + entity.getQualifiedName()
                   + "]. Aborting.");
       }

--- a/javaee-impl/src/main/resources/org/jboss/forge/rest/Endpoint.jv
+++ b/javaee-impl/src/main/resources/org/jboss/forge/rest/Endpoint.jv
@@ -2,71 +2,73 @@ package org.jboss.forge.spec.javaee.rest;
 
 import java.util.List;
 
-import javax.ejb.Stateful;
+import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.PersistenceContextType;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
 
 /**
- * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * 
- *         JAX-RS Example This class produces a RESTful service to read the contents of the table.
  */
-@Stateful
-@Path("/objects")
-@TransactionAttribute
-public class @{entityTable}Endpoint
+@Stateless
+@Path("/@{resourcePath}")
+public class @{entityTable}Resource
 {
-   @PersistenceContext(type = PersistenceContextType.EXTENDED)
+   @PersistenceContext
    private EntityManager em;
 
    @POST
    @Consumes("@{contentType}")
-   public @{entity.getName()} create(@{entity.getName()} entity)
+   public Response create(@{entity.getName()} entity)
    {
-      em.joinTransaction();
       em.persist(entity);
-      return entity;
+      return Response.created(UriBuilder.fromResource(@{entityTable}Resource.class).path(String.valueOf(entity.@{getIdStatement})).build()).build();
    }
 
    @DELETE
    @Path("/{id:[0-9][0-9]*}")
-   @Produces("@{contentType}")
-   public @{entity.getName()} deleteById(@PathParam("id") @{idType} id)
+   public Response deleteById(@PathParam("id") @{idType} id)
    {
-      em.joinTransaction();
-      @{entity.getName()} result = em.find(@{entity.getName()}.class, id);
-      em.remove(result);
-      return result;
+      @{entity.getName()} entity = em.find(@{entity.getName()}.class, id);
+      if (entity == null) {
+        return Response.status(Status.NOT_FOUND).build();
+      }
+      em.remove(entity);
+      return Response.noContent().build();
    }
 
    @GET
    @Path("/{id:[0-9][0-9]*}")
    @Produces("@{contentType}")
-   public @{entity.getName()} findById(@PathParam("id") @{idType} id)
+   public Response findById(@PathParam("id") @{idType} id)
    {
-      return em.find(@{entity.getName()}.class, id);
+      @{entity.getName()} entity = em.find(@{entity.getName()}.class, id);
+      if (entity == null) {
+        return Response.status(Status.NOT_FOUND).build();
+      }
+      return Response.ok(entity).build();
    }
 
    @GET
    @Produces("@{contentType}")
    public List<@{entity.getName()}> listAll()
    {
-      @SuppressWarnings("unchecked")
-      final List<@{entity.getName()}> results = em.createQuery("SELECT x FROM @{entityTable} x").getResultList();
+      final List<@{entity.getName()}> results = em.createQuery("FROM @{entityTable}", @{entity.getName()}.class).getResultList();
       return results;
    }
 
    @PUT
    @Path("/{id:[0-9][0-9]*}")
    @Consumes("@{contentType}")
-   public @{entity.getName()} update(@PathParam("id") @{idType} id, @{entity.getName()} entity)
+   public Response update(@PathParam("id") @{idType} id, @{entity.getName()} entity)
    {
       entity.@{setIdStatement};
-      em.joinTransaction();
       entity = em.merge(entity);
-      return entity;
+      return Response.noContent().build();
    }
 }

--- a/javaee-impl/src/test/java/org/jboss/forge/spec/plugin/RestPluginTest.java
+++ b/javaee-impl/src/test/java/org/jboss/forge/spec/plugin/RestPluginTest.java
@@ -131,15 +131,14 @@ public class RestPluginTest extends AbstractJPATest
       getShell().execute("rest endpoint-from-entity");
 
       JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
-      JavaResource resource = java.getJavaResource(java.getBasePackage() + ".rest.UserEndpoint");
+      JavaResource resource = java.getJavaResource(java.getBasePackage() + ".rest.UserResource");
       JavaClass endpoint = (JavaClass) resource.getJavaSource();
 
-      assertEquals("/user", endpoint.getAnnotation(Path.class).getStringValue());
+      assertEquals("/users", endpoint.getAnnotation(Path.class).getStringValue());
       assertEquals("java.util.List", endpoint.getMethod("listAll").getQualifiedReturnType());
       Method<JavaClass> method = endpoint.getMethod("findById", Long.class);
       Type<JavaClass> returnTypeInspector = method.getReturnTypeInspector();
-      assertEquals("com.test." + PersistenceFacetImpl.DEFAULT_ENTITY_PACKAGE + ".User",
-               returnTypeInspector
+      assertEquals("javax.ws.rs.core.Response", returnTypeInspector
                         .getQualifiedName());
 
       assertTrue(java.getJavaResource(entity).getJavaSource().hasAnnotation(XmlRootElement.class));
@@ -163,10 +162,10 @@ public class RestPluginTest extends AbstractJPATest
       queueInputLines("");
       getShell().execute("rest endpoint-from-entity");
 
-      JavaResource resource = java.getJavaResource(java.getBasePackage() + ".rest.UserEndpoint");
+      JavaResource resource = java.getJavaResource(java.getBasePackage() + ".rest.UserResource");
       JavaClass endpoint = (JavaClass) resource.getJavaSource();
 
-      assertEquals("/user", endpoint.getAnnotation(Path.class).getStringValue());
+      assertEquals("/users", endpoint.getAnnotation(Path.class).getStringValue());
       assertTrue(endpoint.toString().contains("entity.setObjectId(id);"));
       getShell().execute("build");
    }
@@ -188,10 +187,10 @@ public class RestPluginTest extends AbstractJPATest
       queueInputLines("");
       getShell().execute("rest endpoint-from-entity");
 
-      JavaResource resource = java.getJavaResource(java.getBasePackage() + ".rest.User2Endpoint");
+      JavaResource resource = java.getJavaResource(java.getBasePackage() + ".rest.User2Resource");
       JavaClass endpoint = (JavaClass) resource.getJavaSource();
 
-      assertEquals("/user2", endpoint.getAnnotation(Path.class).getStringValue());
+      assertEquals("/user2s", endpoint.getAnnotation(Path.class).getStringValue());
       assertTrue(endpoint.toString().contains("entity.setObjectId(id);"));
       getShell().execute("build");
    }
@@ -213,10 +212,10 @@ public class RestPluginTest extends AbstractJPATest
       queueInputLines("");
       getShell().execute("rest endpoint-from-entity");
 
-      JavaResource resource = java.getJavaResource(java.getBasePackage() + ".rest.User3Endpoint");
+      JavaResource resource = java.getJavaResource(java.getBasePackage() + ".rest.User3Resource");
       JavaClass endpoint = (JavaClass) resource.getJavaSource();
 
-      assertEquals("/user3", endpoint.getAnnotation(Path.class).getStringValue());
+      assertEquals("/user3s", endpoint.getAnnotation(Path.class).getStringValue());
       assertTrue(endpoint.toString().contains("entity.setObjectId(id);"));
       getShell().execute("build");
    }


### PR DESCRIPTION
Hi,

I did some improvements on the rest plugin that I like. But some things are not really restful and I have to change them in the generated code all the time.
1. Restful means stateless. Its not an optional thing. Resources have to be stateless. So the EJBs have to be also Stateless (no extended persistence context). A stateful EJB, that is not bound to a http session makes no sense in my eyes. Its creates new instances all the time...
2. REST is not SOAP. SOAP has Endpoints, REST has Resources. So the resources could not named endpoints. I changed everything form endpoint to resource...
3. I changed the generated code to some typical REST conventions
   3.1. POST creates a Resource and returns the proper status code (created) and URI to the created resource
   3.2. DELETE and PUT should return "no content"
   3.3. Resource should return a 404 if they did not exist

I hope my changes are ok.

Best regards
Sandro
