### PR TITLE
JPA Metamodel Generation

### DIFF
--- a/dist/src/main/resources/modules/org/jboss/forge/javaee/impl/main/module.xml
+++ b/dist/src/main/resources/modules/org/jboss/forge/javaee/impl/main/module.xml
@@ -39,6 +39,14 @@
       <module name="org.slf4j.ext" />
       
       <module name="javax.api" />
+      
+      <module name="org.jboss.forge.maven.api" services="import">
+         <imports>
+            <include path="**" />
+            <include path="META-INF" />
+         </imports>
+      </module>
+      
    </dependencies>
 
 </module>

--- a/javaee-api/src/main/java/org/jboss/forge/spec/javaee/PersistenceMetaModelFacet.java
+++ b/javaee-api/src/main/java/org/jboss/forge/spec/javaee/PersistenceMetaModelFacet.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.spec.javaee;
+
+import org.jboss.forge.project.Facet;
+import org.jboss.forge.project.dependencies.Dependency;
+
+public interface PersistenceMetaModelFacet extends Facet
+{
+   String getProcessor();
+   
+   String getCompilerArgs();
+   
+   Dependency getProcessorDependency();
+}

--- a/javaee-impl/pom.xml
+++ b/javaee-impl/pom.xml
@@ -27,6 +27,11 @@
          <scope>provided</scope>
       </dependency>
       <dependency>
+         <groupId>org.jboss.forge</groupId>
+         <artifactId>forge-maven-api</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
          <groupId>org.jboss.seam.render</groupId>
          <artifactId>seam-render</artifactId>
       </dependency>

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/PersistenceMetaModelFacetImpl.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/PersistenceMetaModelFacetImpl.java
@@ -1,0 +1,195 @@
+package org.jboss.forge.spec.javaee.jpa;
+
+import java.util.List;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+import org.apache.maven.model.Repository;
+import org.jboss.forge.maven.MavenPluginFacet;
+import org.jboss.forge.maven.plugins.Configuration;
+import org.jboss.forge.maven.plugins.ConfigurationBuilder;
+import org.jboss.forge.maven.plugins.ConfigurationElement;
+import org.jboss.forge.maven.plugins.ExecutionBuilder;
+import org.jboss.forge.maven.plugins.MavenPlugin;
+import org.jboss.forge.maven.plugins.MavenPluginBuilder;
+import org.jboss.forge.parser.java.util.Strings;
+import org.jboss.forge.project.dependencies.Dependency;
+import org.jboss.forge.project.dependencies.DependencyBuilder;
+import org.jboss.forge.project.dependencies.DependencyQueryBuilder;
+import org.jboss.forge.project.dependencies.NonSnapshotDependencyFilter;
+import org.jboss.forge.project.facets.BaseFacet;
+import org.jboss.forge.project.facets.DependencyFacet;
+import org.jboss.forge.shell.ShellPrompt;
+import org.jboss.forge.shell.plugins.Alias;
+import org.jboss.forge.shell.plugins.RequiresFacet;
+import org.jboss.forge.spec.javaee.PersistenceFacet;
+import org.jboss.forge.spec.javaee.PersistenceMetaModelFacet;
+import org.jboss.forge.spec.javaee.jpa.api.JPAProvider;
+import org.jboss.forge.spec.javaee.jpa.api.MetaModelProvider;
+import org.jboss.forge.spec.javaee.jpa.api.PersistenceProvider;
+import org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceDescriptor;
+
+@Alias("forge.spec.jpa.metamodel")
+@RequiresFacet({ PersistenceFacet.class, MavenPluginFacet.class })
+public class PersistenceMetaModelFacetImpl extends BaseFacet implements PersistenceMetaModelFacet
+{
+
+   @Inject
+   private BeanManager manager;
+   
+   @Inject
+   private ShellPrompt prompt;
+
+   @Override
+   public boolean install()
+   {
+      MetaModelProvider provider = lookupProvider();
+      addProcessorPlugin(provider);
+      modifyCompilerPlugin();
+      addPluginRepository(provider);
+      return true;
+   }
+
+   @Override
+   public boolean isInstalled()
+   {
+      return processorConfigured(lookupProvider());
+   }
+   
+   @Override
+   public String getProcessor()
+   {
+      return lookupProvider().getProcessor();
+   }
+
+   @Override
+   public String getCompilerArgs()
+   {
+      return lookupProvider().getCompilerArguments();
+   }
+
+   @Override
+   public Dependency getProcessorDependency()
+   {
+      return lookupProvider().getAptDependency();
+   }
+
+   private MetaModelProvider lookupProvider()
+   {
+      PersistenceDescriptor config = project.getFacet(PersistenceFacet.class).getConfig();
+      String providerName = config.listUnits().size() > 0 ? config.listUnits().get(0).getProvider() : null;
+      for (JPAProvider jpaProvider : JPAProvider.values())
+      {
+         PersistenceProvider candidate = jpaProvider.getProvider(manager);
+         if (candidate.getProvider().equals(providerName))
+         {
+            return candidate.getMetaModelProvider();
+         }
+      }
+      return JPAProvider.HIBERNATE.getProvider(manager).getMetaModelProvider();
+   }
+
+   private void addProcessorPlugin(MetaModelProvider provider)
+   {
+      DependencyBuilder processorDependency = createProcessorDependency();
+      Dependency versioned = promptVersion(processorDependency);
+      
+      ConfigurationBuilder configuration = ConfigurationBuilder.create();
+      configuration.createConfigurationElement("processors")
+                  .addChild("processor").setText(provider.getProcessor());
+      if (!Strings.isNullOrEmpty(provider.getCompilerArguments()))
+      {
+         configuration.createConfigurationElement("compilerArguments")
+                  .setText(provider.getCompilerArguments());
+      }
+                
+      ExecutionBuilder execution = ExecutionBuilder.create()
+               .setId("process")
+               .setPhase("generate-sources")
+               .addGoal("process")
+               .setConfig(configuration);
+      
+      Dependency aptDependency = provider.getAptDependency();
+      if (Strings.isNullOrEmpty(aptDependency.getVersion()))
+      {
+         aptDependency = promptVersion(aptDependency);
+      }
+      MavenPluginBuilder processorPlugin = MavenPluginBuilder.create()
+               .setDependency(versioned)
+               .addExecution(execution)
+               .addPluginDependency(aptDependency);
+      
+      project.getFacet(MavenPluginFacet.class).addPlugin(processorPlugin);
+   }
+
+   private DependencyBuilder createProcessorDependency()
+   {
+      DependencyBuilder processorDependency = DependencyBuilder.create()
+               .setGroupId("org.bsc.maven")
+               .setArtifactId("maven-processor-plugin");
+      return processorDependency;
+   }
+
+   private void modifyCompilerPlugin()
+   {
+      Dependency compilerDependency = DependencyBuilder.create()
+               .setGroupId("org.apache.maven.plugins")
+               .setArtifactId("maven-compiler-plugin");
+      MavenPluginFacet pluginFacet = project.getFacet(MavenPluginFacet.class);
+      MavenPlugin compiler = pluginFacet.getPlugin(compilerDependency);
+      Configuration config = compiler.getConfig();
+      if (!config.hasConfigurationElement("proc"))
+      {
+         ConfigurationElement proc = ConfigurationBuilder.create().createConfigurationElement("proc").setText("none");
+         config.addConfigurationElement(proc);
+      }
+      pluginFacet.updatePlugin(compiler);
+   }
+   
+   private boolean processorConfigured(MetaModelProvider provider)
+   {
+      DependencyBuilder dependency = createProcessorDependency().setVersion(null);
+      MavenPluginFacet pluginFacet = project.getFacet(MavenPluginFacet.class);
+      if (pluginFacet.hasPlugin(dependency))
+      {
+         MavenPlugin plugin = pluginFacet.getPlugin(dependency);
+         if (plugin.listExecutions().size() > 0)
+         {
+            Configuration config = plugin.listExecutions().get(0).getConfig();
+            if (config.hasConfigurationElement("processors"))
+            {
+               ConfigurationElement element = config.getConfigurationElement("processors").getChildByName("processor");
+               return element.getText().equals(provider.getProcessor());
+            }
+         }
+      }
+      return false;
+   }
+   
+   private void addPluginRepository(MetaModelProvider provider)
+   {
+      Repository repository = provider.getAptPluginRepository();
+      if (repository != null)
+      {
+         MavenPluginFacet pluginFacet = project.getFacet(MavenPluginFacet.class);
+         pluginFacet.addPluginRepository(repository.getName(), repository.getUrl());
+      }
+   }
+   
+   private Dependency promptVersion(Dependency dependency)
+   {
+      DependencyFacet dependencyFacet = project.getFacet(DependencyFacet.class);
+      Dependency result = dependency;
+      List<Dependency> versions = dependencyFacet.resolveAvailableVersions(DependencyQueryBuilder.create(dependency)
+               .setFilter(new NonSnapshotDependencyFilter()));
+      if (versions.size() > 0)
+      {
+         Dependency deflt = versions.get(versions.size() - 1);
+         result = prompt.promptChoiceTyped("Use which version of '" + dependency.getArtifactId()
+                  + "' ?", versions, deflt);
+      }
+      return result;
+   }
+
+}

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/PersistencePlugin.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/PersistencePlugin.java
@@ -33,6 +33,7 @@ import org.jboss.forge.shell.plugins.Plugin;
 import org.jboss.forge.shell.plugins.RequiresFacet;
 import org.jboss.forge.shell.plugins.RequiresProject;
 import org.jboss.forge.spec.javaee.PersistenceFacet;
+import org.jboss.forge.spec.javaee.PersistenceMetaModelFacet;
 import org.jboss.forge.spec.javaee.jpa.api.DatabaseType;
 import org.jboss.forge.spec.javaee.jpa.api.JPAContainer;
 import org.jboss.forge.spec.javaee.jpa.api.JPADataSource;
@@ -178,11 +179,21 @@ public class PersistencePlugin implements Plugin
 
       jpa.saveConfig(config);
 
+      installMetaModelGenerator();
       installAdditionalDependencies(out, container, jpap, provider, providerVersion);
 
       if (project.hasFacet(PersistenceFacet.class))
       {
          ShellMessages.success(out, "Persistence (JPA) is installed.");
+      }
+   }
+   
+   private void installMetaModelGenerator()
+   {
+      if (!project.hasFacet(PersistenceMetaModelFacet.class) 
+               && prompt.promptBoolean("Do you want to install a JPA 2 metamodel generator?", false))
+      {
+         request.fire(new InstallFacets(PersistenceMetaModelFacet.class));
       }
    }
 

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/api/MetaModelProvider.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/api/MetaModelProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.spec.javaee.jpa.api;
+
+import org.apache.maven.model.Repository;
+import org.jboss.forge.project.dependencies.Dependency;
+
+
+public interface MetaModelProvider
+{
+
+   /**
+    * The dependency containing the APT processor class.
+    */
+   Dependency getAptDependency();
+   
+   /**
+    * The processor class name.
+    */
+   String getProcessor();
+   
+   /**
+    * Additional compiler arguments (if any, returns {@code null} otherwise).
+    */
+   String getCompilerArguments();
+   
+   /**
+    * The dependency does not exist in Maven central, alternative repository.
+    * Returns {@code null} if no other repository is needed.
+    */
+   Repository getAptPluginRepository();
+
+}

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/api/PersistenceProvider.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/api/PersistenceProvider.java
@@ -32,4 +32,9 @@ public interface PersistenceProvider
     * List any dependencies required by this provider.
     */
    List<Dependency> listDependencies();
+   
+   /**
+    * The JPA 2 meta model provider related to this persistence provider.
+    */
+   MetaModelProvider getMetaModelProvider();
 }

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/EclipseLinkMetaModelProvider.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/EclipseLinkMetaModelProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.spec.javaee.jpa.provider;
+
+import org.apache.maven.model.Repository;
+import org.jboss.forge.project.dependencies.Dependency;
+import org.jboss.forge.project.dependencies.DependencyBuilder;
+import org.jboss.forge.spec.javaee.jpa.api.MetaModelProvider;
+
+public class EclipseLinkMetaModelProvider implements MetaModelProvider
+{
+
+   @Override
+   public Dependency getAptDependency()
+   {
+      return DependencyBuilder.create()
+               .setGroupId("org.eclipse.persistence")
+               .setArtifactId("eclipselink")
+               .setVersion("2.4.0");
+   }
+
+   @Override
+   public String getProcessor()
+   {
+      return "org.eclipse.persistence.internal.jpa.modelgen.CanonicalModelProcessor";
+   }
+
+   @Override
+   public String getCompilerArguments()
+   {
+      return "-Aeclipselink.persistencexml=src/main/resources/META-INF/persistence.xml";
+   }
+
+   @Override
+   public Repository getAptPluginRepository()
+   {
+      Repository repo = new Repository();
+      repo.setName("EclipseLink");
+      repo.setUrl("http://download.eclipse.org/rt/eclipselink/maven.repo");
+      return repo;
+   }
+
+}

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/EclipseLinkProvider.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/EclipseLinkProvider.java
@@ -15,6 +15,7 @@ import org.jboss.forge.project.dependencies.Dependency;
 import org.jboss.forge.project.dependencies.DependencyBuilder;
 import org.jboss.forge.spec.javaee.jpa.api.DatabaseType;
 import org.jboss.forge.spec.javaee.jpa.api.JPADataSource;
+import org.jboss.forge.spec.javaee.jpa.api.MetaModelProvider;
 import org.jboss.forge.spec.javaee.jpa.api.PersistenceProvider;
 import org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceUnitDef;
 
@@ -98,6 +99,12 @@ public class EclipseLinkProvider implements PersistenceProvider
    {
       return Arrays.asList((Dependency) DependencyBuilder.create("org.eclipse.persistence:eclipselink"),
                (Dependency) DependencyBuilder.create("org.eclipse.persistence:javax.persistence"));
+   }
+
+   @Override
+   public MetaModelProvider getMetaModelProvider()
+   {
+      return new EclipseLinkMetaModelProvider();
    }
 
 }

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/HibernateMetaModelProvider.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/HibernateMetaModelProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.spec.javaee.jpa.provider;
+
+import org.apache.maven.model.Repository;
+import org.jboss.forge.project.dependencies.Dependency;
+import org.jboss.forge.project.dependencies.DependencyBuilder;
+import org.jboss.forge.spec.javaee.jpa.api.MetaModelProvider;
+
+public class HibernateMetaModelProvider implements MetaModelProvider
+{
+
+   @Override
+   public Dependency getAptDependency()
+   {
+      return DependencyBuilder.create()
+               .setGroupId("org.hibernate")
+               .setArtifactId("hibernate-jpamodelgen");
+   }
+
+   @Override
+   public String getProcessor()
+   {
+      return "org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor";
+   }
+
+   @Override
+   public String getCompilerArguments()
+   {
+      return null;
+   }
+
+   @Override
+   public Repository getAptPluginRepository()
+   {
+      return null;
+   }
+
+}

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/HibernateProvider.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/HibernateProvider.java
@@ -15,6 +15,7 @@ import org.jboss.forge.project.dependencies.Dependency;
 import org.jboss.forge.project.dependencies.DependencyBuilder;
 import org.jboss.forge.spec.javaee.jpa.api.DatabaseType;
 import org.jboss.forge.spec.javaee.jpa.api.JPADataSource;
+import org.jboss.forge.spec.javaee.jpa.api.MetaModelProvider;
 import org.jboss.forge.spec.javaee.jpa.api.PersistenceProvider;
 import org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceUnitDef;
 
@@ -90,5 +91,11 @@ public class HibernateProvider implements PersistenceProvider
    public List<Dependency> listDependencies()
    {
       return Arrays.asList((Dependency) DependencyBuilder.create("org.hibernate:hibernate-entitymanager"));
+   }
+
+   @Override
+   public MetaModelProvider getMetaModelProvider()
+   {
+      return new HibernateMetaModelProvider();
    }
 }

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/InfinispanProvider.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/InfinispanProvider.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.jboss.forge.project.dependencies.Dependency;
 import org.jboss.forge.project.dependencies.DependencyBuilder;
 import org.jboss.forge.spec.javaee.jpa.api.JPADataSource;
+import org.jboss.forge.spec.javaee.jpa.api.MetaModelProvider;
 import org.jboss.forge.spec.javaee.jpa.api.PersistenceProvider;
 import org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceUnitDef;
 
@@ -40,5 +41,11 @@ public class InfinispanProvider implements PersistenceProvider
    {
       return Arrays.asList((Dependency) DependencyBuilder.create("org.hibernate.ogm:hibernate-ogm-core"),
                (Dependency) DependencyBuilder.create("org.hibernate:hibernate-search"));
+   }
+
+   @Override
+   public MetaModelProvider getMetaModelProvider()
+   {
+      return new HibernateMetaModelProvider();
    }
 }

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/OpenJPAMetaModelProvider.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/OpenJPAMetaModelProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.spec.javaee.jpa.provider;
+
+import org.apache.maven.model.Repository;
+import org.jboss.forge.project.dependencies.Dependency;
+import org.jboss.forge.project.dependencies.DependencyBuilder;
+import org.jboss.forge.spec.javaee.jpa.api.MetaModelProvider;
+
+public class OpenJPAMetaModelProvider implements MetaModelProvider
+{
+
+   @Override
+   public Dependency getAptDependency()
+   {
+      return DependencyBuilder.create()
+               .setGroupId("org.apache.openjpa")
+               .setArtifactId("openjpa-persistence");
+   }
+
+   @Override
+   public String getProcessor()
+   {
+      return "org.apache.openjpa.persistence.meta.AnnotationProcessor6";
+   }
+
+   @Override
+   public String getCompilerArguments()
+   {
+      return "-Aopenjpa.metamodel=true";
+   }
+
+   @Override
+   public Repository getAptPluginRepository()
+   {
+      return null;
+   }
+
+}

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/OpenJPAProvider.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/provider/OpenJPAProvider.java
@@ -15,6 +15,7 @@ import org.jboss.forge.project.dependencies.Dependency;
 import org.jboss.forge.project.dependencies.DependencyBuilder;
 import org.jboss.forge.spec.javaee.jpa.api.DatabaseType;
 import org.jboss.forge.spec.javaee.jpa.api.JPADataSource;
+import org.jboss.forge.spec.javaee.jpa.api.MetaModelProvider;
 import org.jboss.forge.spec.javaee.jpa.api.PersistenceProvider;
 import org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceUnitDef;
 
@@ -85,6 +86,12 @@ public class OpenJPAProvider implements PersistenceProvider
    public List<Dependency> listDependencies()
    {
       return Arrays.asList((Dependency) DependencyBuilder.create("org.apache.openjpa:openjpa-all"));
+   }
+
+   @Override
+   public MetaModelProvider getMetaModelProvider()
+   {
+      return new OpenJPAMetaModelProvider();
    }
 
 }

--- a/javaee-impl/src/test/java/org/jboss/forge/spec/PersistenceMetaModelFacetTest.java
+++ b/javaee-impl/src/test/java/org/jboss/forge/spec/PersistenceMetaModelFacetTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.spec;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.maven.MavenPluginFacet;
+import org.jboss.forge.maven.plugins.Configuration;
+import org.jboss.forge.maven.plugins.MavenPlugin;
+import org.jboss.forge.project.dependencies.DependencyBuilder;
+import org.jboss.forge.spec.javaee.PersistenceMetaModelFacet;
+import org.jboss.forge.spec.jpa.AbstractJPATest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class PersistenceMetaModelFacetTest extends AbstractJPATest
+{
+
+   @Test
+   public void testInstallFacet() throws Exception
+   {
+      // when
+      queueInputLines("", "");
+      getShell().execute("project install-facet forge.spec.jpa.metamodel");
+      
+      // then
+      MavenPluginFacet facet = getProject().getFacet(MavenPluginFacet.class);
+      MavenPlugin processorPlugin = facet.getPlugin(DependencyBuilder.create("org.bsc.maven:maven-processor-plugin"));
+      MavenPlugin compilerPlugin = facet.getPlugin(DependencyBuilder.create("org.apache.maven.plugins:maven-compiler-plugin"));
+      
+      assertTrue(getProject().hasFacet(PersistenceMetaModelFacet.class));
+      assertNotNull(processorPlugin);
+      assertEquals(1, processorPlugin.listExecutions().size());
+      Configuration processorConfig = processorPlugin.listExecutions().get(0).getConfig();
+      assertEquals("org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor", 
+               processorConfig.getConfigurationElement("processors").getChildByName("processor").getText());
+      Configuration compilerConfig = compilerPlugin.getConfig();
+      assertEquals("none", compilerConfig.getConfigurationElement("proc").getText());
+   }
+
+}

--- a/javaee-impl/src/test/java/org/jboss/forge/spec/jpa/PersistencePluginTest.java
+++ b/javaee-impl/src/test/java/org/jboss/forge/spec/jpa/PersistencePluginTest.java
@@ -11,8 +11,10 @@ import java.util.List;
 import junit.framework.Assert;
 
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.maven.MavenCoreFacet;
 import org.jboss.forge.project.Project;
 import org.jboss.forge.spec.javaee.PersistenceFacet;
+import org.jboss.forge.spec.javaee.PersistenceMetaModelFacet;
 import org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceUnitDef;
 import org.junit.Test;
@@ -30,7 +32,7 @@ public class PersistencePluginTest extends AbstractJPATest
    {
       Project project = getProject();
 
-      queueInputLines("");
+      queueInputLines("", "");
       getShell().execute(
                "persistence setup --provider HIBERNATE --container CUSTOM_JTA --jndiDataSource java:jboss:jta-ds ");
 
@@ -46,7 +48,7 @@ public class PersistencePluginTest extends AbstractJPATest
    {
       Project project = getProject();
 
-      queueInputLines("");
+      queueInputLines("", "");
       getShell().execute(
                "persistence setup --provider HIBERNATE --container JBOSS_AS7");
 
@@ -62,7 +64,7 @@ public class PersistencePluginTest extends AbstractJPATest
    {
       Project project = getProject();
 
-      queueInputLines("");
+      queueInputLines("", "");
       getShell().execute(
                "persistence setup --provider HIBERNATE --container JBOSS_AS7");
 
@@ -78,7 +80,7 @@ public class PersistencePluginTest extends AbstractJPATest
    {
       Project project = getProject();
 
-      queueInputLines("");
+      queueInputLines("", "");
       getShell().execute(
                "persistence setup --provider HIBERNATE --container JBOSS_AS7");
 
@@ -106,7 +108,7 @@ public class PersistencePluginTest extends AbstractJPATest
    {
       Project project = getProject();
 
-      queueInputLines("");
+      queueInputLines("", "");
       getShell().execute(
                "persistence setup --provider HIBERNATE --container JBOSS_AS7 --database MYSQL");
 
@@ -125,7 +127,7 @@ public class PersistencePluginTest extends AbstractJPATest
    {
       Project project = getProject();
 
-      queueInputLines("");
+      queueInputLines("", "");
       getShell()
                .execute(
                         "persistence setup --provider HIBERNATE --container JBOSS_AS6 --database MYSQL_INNODB --jndiDataSource java:demo");
@@ -140,5 +142,21 @@ public class PersistencePluginTest extends AbstractJPATest
       Assert.assertEquals("org.hibernate.dialect.MySQLInnoDBDialect", unit.getProperties().get(4).getValue());
 
       Assert.assertEquals(5, unit.getProperties().size());
+   }
+
+   @Test
+   public void testEclipseLinkWithMetaModel() throws Exception
+   {
+      Project project = getProject();
+
+      queueInputLines("y", "", "");
+      getShell().execute("persistence setup --provider ECLIPSELINK --container GLASSFISH_3");
+
+      Assert.assertTrue(project.hasFacet(PersistenceMetaModelFacet.class));
+      PersistenceMetaModelFacet facet = project.getFacet(PersistenceMetaModelFacet.class);
+      Assert.assertTrue(facet.getCompilerArgs().contains("eclipselink.persistencexml"));
+      Assert.assertEquals("org.eclipse.persistence.internal.jpa.modelgen.CanonicalModelProcessor", facet.getProcessor());
+      Assert.assertEquals("eclipselink", facet.getProcessorDependency().getArtifactId());
+      Assert.assertEquals(1, project.getFacet(MavenCoreFacet.class).getPOM().getPluginRepositories().size());
    }
 }

--- a/maven-api/src/main/java/org/jboss/forge/maven/MavenPluginFacet.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/MavenPluginFacet.java
@@ -51,6 +51,8 @@ public interface MavenPluginFacet extends Facet
    void addPlugin(MavenPlugin plugin);
 
    void removePlugin(Dependency dependency);
+   
+   void updatePlugin(final MavenPlugin plugin);
 
    /**
     * Add a {@link KnownRepository} to the project build system. This is where dependencies can be found, downloaded,

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPlugin.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPlugin.java
@@ -7,9 +7,9 @@
 
 package org.jboss.forge.maven.plugins;
 
-import org.jboss.forge.project.dependencies.Dependency;
-
 import java.util.List;
+
+import org.jboss.forge.project.dependencies.Dependency;
 
 /**
  * Represents a Maven plugin
@@ -26,4 +26,7 @@ public interface MavenPlugin extends PluginElement
    List<Execution> listExecutions();
 
    boolean isExtensionsEnabled();
+   
+   List<Dependency> getDirectDependencies();
+   
 }

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPluginBuilder.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPluginBuilder.java
@@ -75,6 +75,12 @@ public class MavenPluginBuilder implements MavenPlugin, PluginElement
       plugin.addExecution(execution);
       return this;
    }
+   
+   public MavenPluginBuilder addPluginDependency(final Dependency pluginDependency)
+   {
+      plugin.addPluginDependency(pluginDependency);
+      return this;
+   }
 
    public MavenPluginBuilder setExtensions(boolean extensions) {
        plugin.setExtenstions(extensions);
@@ -106,4 +112,11 @@ public class MavenPluginBuilder implements MavenPlugin, PluginElement
 
       return builder;
    }
+
+   @Override
+   public List<Dependency> getDirectDependencies()
+   {
+      return plugin.getDirectDependencies();
+   }
+
 }

--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPluginImpl.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPluginImpl.java
@@ -16,10 +16,12 @@ import org.jboss.forge.project.dependencies.Dependency;
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
 public class MavenPluginImpl implements MavenPlugin {
+   
     private Dependency dependency;
     private Configuration configuration;
     private final List<Execution> executions = new ArrayList<Execution>();
     private boolean extensions;
+    private List<Dependency> pluginDependencies = new ArrayList<Dependency>();
 
     public MavenPluginImpl() {
     }
@@ -55,21 +57,16 @@ public class MavenPluginImpl implements MavenPlugin {
     public boolean isExtensionsEnabled() {
         return extensions;
     }
+    
+    @Override
+    public List<Dependency> getDirectDependencies() {
+       return pluginDependencies;
+    }
 
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder("<plugin>");
-        if (dependency.getGroupId() != null) {
-            b.append("<groupId>").append(dependency.getGroupId()).append("</groupId>");
-        }
-
-        if (dependency.getArtifactId() != null) {
-            b.append("<artifactId>").append(dependency.getArtifactId()).append("</artifactId>");
-        }
-
-        if (dependency.getVersion() != null) {
-            b.append("<version>").append(dependency.getVersion()).append("</version>");
-        }
+        appendDependency(b, dependency);
 
         if(extensions) {
             b.append("<extensions>true</extensions>");
@@ -86,6 +83,16 @@ public class MavenPluginImpl implements MavenPlugin {
             }
             b.append("</executions>");
         }
+        
+        if (pluginDependencies.size() > 0) {
+           b.append("<dependencies>");
+           for (Dependency pluginDependency : pluginDependencies) {
+               b.append("<dependency>");
+               appendDependency(b, pluginDependency);
+               b.append("</dependency>");
+           }
+           b.append("</dependencies>");
+       }
 
         b.append("</plugin>");
         return b.toString();
@@ -102,4 +109,23 @@ public class MavenPluginImpl implements MavenPlugin {
     public void setExtenstions(boolean extenstions) {
         this.extensions = extenstions;
     }
+    
+    public void addPluginDependency(final Dependency dependency) {
+       pluginDependencies.add(dependency);
+    }
+    
+    private void appendDependency(StringBuilder buffer, Dependency appendDependency) {
+       if (appendDependency.getGroupId() != null) {
+          buffer.append("<groupId>").append(appendDependency.getGroupId()).append("</groupId>");
+      }
+
+      if (appendDependency.getArtifactId() != null) {
+         buffer.append("<artifactId>").append(appendDependency.getArtifactId()).append("</artifactId>");
+      }
+
+      if (appendDependency.getVersion() != null) {
+         buffer.append("<version>").append(appendDependency.getVersion()).append("</version>");
+      }
+    }
+
 }


### PR DESCRIPTION
Initial version - likely to be improvable :)

Adds a maven-processor-plugin with a JPA metamodel annotation processor configured (plus any compiler args and plugin dependency if needed). The annotation processor depends on the persistence provider or defaults to Hibernate.

Not sure if modelling this as a spec facet is correct, what do you think?
