### PR TITLE
Enforce some version rules on Forge build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -712,6 +712,29 @@
       <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>1.1.1</version>
+            <configuration>
+               <rules>
+                  <requireMavenVersion>
+                     <version>[3.0,4.0)</version>
+                  </requireMavenVersion>
+                  <requireJavaVersion>
+                     <version>[1.6.0-30,1.7)</version>
+                  </requireJavaVersion>
+               </rules>
+            </configuration>
+            <executions>
+               <execution>
+                  <id>enforce-versions</id>
+                  <goals>
+                     <goal>enforce</goal>
+                  </goals>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
                <source>1.6</source>


### PR DESCRIPTION
Forge can be build only with Java versions equal or higher than 1.6.0_30 and with Mave versions equal or higher than 3.0

Tested with JDK 1.6.0_29, 1.6.0_35, 1.7. Tested with Maven 2.2.1 and Maven 3.0.3
