### PR TITLE
Publish Forge's javadoc and sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ bin/
 docs/reference/src/main/docbook/en-US/version_info.xml
 .idea
 .forge_settings
+sources/
+javadoc/
+/*/resources

--- a/dist/build.xml
+++ b/dist/build.xml
@@ -18,7 +18,8 @@
 
 	<import file="lib.xml" />
 
-	<property name="output.dir" value="target/forge-distribution-${forge.release.version}" />
+	<property name="target.dir" value="target" />
+	<property name="output.dir" value="${target.dir}/forge-distribution-${forge.release.version}" />
 	<target name="copy-files">
 		<copy todir="${output.dir}">
 			<fileset dir="src/main/resources">
@@ -428,6 +429,11 @@
 	<target name="bundles">
 	</target>
 
+	<target name="docs">
+		<copy file="../javadoc/forge-core-javadoc.jar" todir="${target.dir}"/>
+		<copy file="../sources/forge-core-sources.jar" todir="${target.dir}"/>
+	</target>
+
 	<target name="clean-target">
 		<delete dir="${output.dir}" />
 	</target>
@@ -436,5 +442,5 @@
 		<delete file="maven-ant-tasks.jar" />
 	</target>
 
-	<target name="all" depends="clean-target, modules, bundles, copy-files, make-dirs" />
+	<target name="all" depends="clean-target, modules, bundles, copy-files, docs, make-dirs" />
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -618,8 +618,49 @@
                </archive>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.8.1</version>
+            <configuration>
+               <!-- Default configuration for all reports -->
+               <finalName>forge-core</finalName>
+               <outputDirectory>${project.basedir}/javadoc</outputDirectory>
+               <destDir>${project.basedir}/javadoc</destDir>
+               <jarOutputDirectory>${project.basedir}/javadoc</jarOutputDirectory>
+            </configuration>
+            <executions>
+               <execution>
+                  <id>aggregate</id>
+                  <goals>
+                     <goal>aggregate-jar</goal>
+                  </goals>
+                  <phase>package</phase>
+                  <configuration>
+                     <!-- Specific configuration for the aggregate report -->
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <configuration>
+               <!-- Default configuration for all reports -->
+               <finalName>forge-core</finalName>
+               <outputDirectory>${project.basedir}/sources</outputDirectory>
+            </configuration>
+            <executions>
+               <execution>
+                  <id>aggregate-sources</id>
+                  <goals>
+                      <goal>aggregate</goal>
+                  </goals>
+                  <phase>package</phase>
+               </execution>
+            </executions>
+         </plugin>
       </plugins>
-
 
       <pluginManagement>
          <plugins>
@@ -656,30 +697,6 @@
                      </manifestSections>
                   </archive>
                </configuration>
-            </plugin>
-
-            <plugin>
-               <groupId>org.apache.maven.plugins</groupId>
-               <artifactId>maven-javadoc-plugin</artifactId>
-               <version>2.8.1</version>
-               <configuration>
-                  <!-- Default configuration for all reports -->
-                  <outputDirectory>${project.build.directory}/javadoc/${project.version}</outputDirectory>
-                  <reportOutputDirectory>${project.build.directory}/javadoc/${project.version}</reportOutputDirectory>
-                  <destDir>${project.build.directory}/javadoc/${project.version}</destDir>
-               </configuration>
-               <executions>
-                  <execution>
-                     <id>aggregate</id>
-                     <goals>
-                        <goal>aggregate</goal>
-                     </goals>
-                     <phase>site</phase>
-                     <configuration>
-                        <!-- Specific configuration for the aggregate report -->
-                     </configuration>
-                  </execution>
-               </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Things to watch while you are reviewing the change:
- the parent project has a target directory with just one subdirectory inside - javadoc-bundle-options. I didn't find a way to do without it...
- on the forge root, the build generates two directories: a javadoc directory which contains forge-core-javadoc.jar and sources directory with forge-core-sources.jar. Both directories are in .gitignore
- the dist project copies both files to its target directory. They are jars, but I can change their name and extensions
- there is a resources directory under each project with sources that contain two identical jars (but with different name). It's in .gitignore too
- these things happen in every forge build, even though we have a javadoc profile declared in pom.xml
