### PR TITLE
FORGE-367

### DIFF
--- a/parser-java/src/main/java/org/jboss/forge/parser/java/impl/ImportImpl.java
+++ b/parser-java/src/main/java/org/jboss/forge/parser/java/impl/ImportImpl.java
@@ -55,7 +55,15 @@ public class ImportImpl implements Import
    @Override
    public Import setName(final String name)
    {
-      imprt.setName(ast.newName(Types.tokenizeClassName(name)));
+      if (name.endsWith(".*"))
+      {
+         imprt.setName(ast.newName(Types.tokenizeClassName(name.replaceAll("\\.\\*", ""))));
+         imprt.setOnDemand(true);
+      }
+      else
+      {
+         imprt.setName(ast.newName(Types.tokenizeClassName(name)));
+      }
       return this;
    }
 

--- a/parser-java/src/test/java/org/jboss/forge/test/parser/java/common/WildCardImportsTest.java
+++ b/parser-java/src/test/java/org/jboss/forge/test/parser/java/common/WildCardImportsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.test.parser.java.common;
+
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.forge.parser.JavaParser;
+import org.jboss.forge.parser.java.JavaClass;
+import org.junit.Test;
+
+public class WildCardImportsTest
+{
+
+   @Test
+   public void testImportWithWildCard() throws ClassNotFoundException
+   {
+      JavaClass javaClass = JavaParser.create(JavaClass.class);
+      javaClass.setPackage("it.coopservice.test");
+      javaClass.setName("SimpleClass");
+      javaClass.addImport("org.junit.Assert.*");
+      assertTrue(javaClass.getImport("org.junit.Assert") != null);
+      assertTrue(javaClass.getImport("org.junit.Assert").isWildcard());
+   }
+
+   @Test
+   public void testImportStaticAndWithWildCard() throws ClassNotFoundException
+   {
+      JavaClass javaClass = JavaParser.create(JavaClass.class);
+      javaClass.setPackage("it.coopservice.test");
+      javaClass.setName("SimpleClass");
+      javaClass.addImport("org.junit.Assert.*")
+               .setStatic(true);
+      assertTrue(javaClass.getImport("org.junit.Assert") != null);
+      assertTrue(javaClass.getImport("org.junit.Assert").isStatic());
+      assertTrue(javaClass.getImport("org.junit.Assert").isWildcard());
+   }
+
+}


### PR DESCRIPTION
In this version we accept wildcard inside the className and we accept static option:
- javaClass.addImport("org.junit.Assert.*").setStatic(true);

If you want we could add a new method:
- javaClass.addStaticImport("org.junit.Assert.*");
