### PR TITLE
Create javadoc and sources archives of Forge

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -29,70 +29,6 @@
    <build>
       <sourceDirectory>${project.build.directory}/sources</sourceDirectory>
       <plugins>
-         <plugin>         
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-               <execution>
-                  <id>copy-sources</id>
-                  <goals>
-                     <goal>unpack-dependencies</goal>
-                  </goals>
-                  <configuration>
-                     <classifier>sources</classifier>
-                     <outputDirectory>${project.build.directory}/sources</outputDirectory>
-                     <excludeTransitive>true</excludeTransitive>                     
-                     <includeArtifactIds>forge-dev-plugins,forge-event-bus-api,forge-git-tools,forge-javaee-api,forge-javaee-impl,forge-maven-api,forge-parser-java,forge-parser-java-api,forge-parser-xml,forge-plugin-loader,forge-project-model-maven,forge-scaffold-api,forge-scaffold-faces,forge-scaffold-metawidget,forge-scaffold-plugins,forge-shell,forge-shell-api</includeArtifactIds>
-                  </configuration>
-               </execution>
-               <execution>
-                  <id>copy-sources-javadoc</id>
-                  <goals>
-                     <goal>unpack-dependencies</goal>
-                  </goals>
-                  <configuration>
-                     <classifier>sources</classifier>
-                     <outputDirectory>${project.build.directory}/sources-javadoc</outputDirectory>
-                     <excludeTransitive>true</excludeTransitive>                     
-                     <includeArtifactIds>forge-dev-plugins,forge-event-bus-api,forge-git-tools,forge-javaee-api,forge-maven-api,forge-parser-java-api,forge-parser-xml,forge-scaffold-api,forge-shell-api</includeArtifactIds>
-                  </configuration>
-               </execution>
-            </executions>
-         </plugin>         
-         
-         <plugin>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <executions>
-               <execution>
-                  <id>javadoc-jar</id>
-                  <phase>package</phase>
-                  <goals>
-                     <goal>jar</goal>
-                  </goals>
-                  <configuration>
-                     <sourcepath>${project.build.directory}/sources-javadoc</sourcepath>
-                     <links>
-                       <link>http://download.oracle.com/javaee/6/api</link>
-                       <link>http://download.oracle.com/javase/6/docs/api/</link>
-                     </links>                     
-                     <keywords>true</keywords>
-                     <author>true</author>
-                  </configuration>
-               </execution>
-            </executions>
-         </plugin>
-
-         <plugin>
-           <artifactId>maven-source-plugin</artifactId>
-           <executions>
-             <execution>
-               <id>attach-sources</id>
-               <goals>
-                 <goal>jar</goal>
-               </goals>
-             </execution>
-           </executions>
-         </plugin>
 
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -130,7 +66,7 @@
                   <phase>package</phase>
                </execution>
             </executions>
-         </plugin>
+         </plugin> 
 
       </plugins>
    </build>
@@ -498,6 +434,74 @@
          </activation>
          <build>
             <plugins>
+               <plugin>         
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-dependency-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>copy-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                           <classifier>sources</classifier>
+                           <outputDirectory>${project.build.directory}/sources</outputDirectory>
+                           <excludeTransitive>true</excludeTransitive>                     
+                           <includeArtifactIds>forge-dev-plugins,forge-event-bus-api,forge-git-tools,forge-javaee-api,forge-javaee-impl,forge-maven-api,forge-parser-java,forge-parser-java-api,forge-parser-xml,forge-plugin-loader,forge-project-model-maven,forge-scaffold-api,forge-scaffold-faces,forge-scaffold-metawidget,forge-scaffold-plugins,forge-shell,forge-shell-api</includeArtifactIds>
+                        </configuration>
+                     </execution>
+                     <execution>
+                        <id>copy-sources-javadoc</id>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                           <classifier>sources</classifier>
+                           <outputDirectory>${project.build.directory}/sources-javadoc</outputDirectory>
+                           <excludeTransitive>true</excludeTransitive>                     
+                           <includeArtifactIds>forge-dev-plugins,forge-event-bus-api,forge-git-tools,forge-javaee-api,forge-maven-api,forge-parser-java-api,forge-parser-xml,forge-scaffold-api,forge-shell-api</includeArtifactIds>
+                        </configuration>
+                     </execution>
+                  </executions>
+               </plugin>         
+               
+               <plugin>
+                  <artifactId>maven-javadoc-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>javadoc-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                           <sourcepath>${project.build.directory}/sources-javadoc</sourcepath>
+                           <links>
+                             <link>http://download.oracle.com/javaee/6/api</link>
+                             <link>http://download.oracle.com/javase/6/docs/api/</link>
+                           </links>                     
+                           <keywords>true</keywords>
+                           <author>true</author>
+                        </configuration>
+                     </execution>
+                  </executions>
+               </plugin>
+
+               <plugin>
+                 <artifactId>maven-source-plugin</artifactId>
+                 <executions>
+                   <execution>
+                     <id>attach-sources</id>
+                     <phase>package</phase>
+                     <goals>
+                       <goal>jar</goal>
+                     </goals>
+                   </execution>
+                 </executions>
+               </plugin>
+               
                <plugin>
                   <groupId>org.codehaus.mojo</groupId>
                   <artifactId>license-maven-plugin</artifactId>


### PR DESCRIPTION
Sources and javadocs are packaged in jar files in the target directory of the dist project: forge-distribution-<version>.jar and forge-distribution-<version>-sources.jar
