### PR TITLE
[FORGE-706] Git tools additions for .gitignore

### DIFF
--- a/git-tools-tests/src/test/java/org/jboss/forge/git/gitignore/GitIgnorePluginTest.java
+++ b/git-tools-tests/src/test/java/org/jboss/forge/git/gitignore/GitIgnorePluginTest.java
@@ -1,0 +1,163 @@
+package org.jboss.forge.git.gitignore;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.forge.resources.Resource;
+import org.jboss.forge.shell.util.Streams;
+import org.jboss.forge.test.AbstractShellTest;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+
+public class GitIgnorePluginTest extends AbstractShellTest
+{
+
+   @Deployment
+   public static JavaArchive getDeployment()
+   {
+      return AbstractShellTest.getDeployment().addPackages(true, GitIgnore.class.getPackage());
+   }
+
+   @Test
+   public void should_setup_gibo() throws Exception
+   {
+      // given
+      initializeJavaProject();
+      Resource<?> cloneFolder = cloneFolder();
+      queueInputLines(cloneFolder.getFullyQualifiedName(), "\n");
+
+      // when
+      getShell().execute("project install-facet forge.vcs.git");
+      getShell().execute("gitignore setup");
+
+      // then
+      List<Resource<?>> resources = cloneFolder.listResources();
+      assertNotNull(resources);
+      assertFalse(resources.isEmpty());
+
+      int counter = 0;
+      for (Resource<?> resource : resources)
+      {
+         String name = resource.getName();
+         if (name != null && name.endsWith(".gitignore"))
+         {
+            counter++;
+         }
+      }
+      assertTrue(counter > 0);
+   }
+   
+   @Test
+   public void should_update_gibo() throws Exception
+   {
+      // given
+      initializeJavaProject();
+      Resource<?> cloneFolder = cloneFolder();
+      queueInputLines(cloneFolder.getFullyQualifiedName(), "\n");
+
+      // when
+      getShell().execute("project install-facet forge.vcs.git");
+      getShell().execute("gitignore setup");
+      getShell().execute("gitignore update-repo");
+
+      // then
+      assertTrue(getOutput().contains("Local gitignore repository updated"));
+   }
+   
+   @Test
+   public void should_list_templates() throws Exception
+   {
+      // given
+      initializeJavaProject();
+      Resource<?> cloneFolder = cloneFolder();
+      queueInputLines(cloneFolder.getFullyQualifiedName(), "\n");
+
+      // when
+      getShell().execute("project install-facet forge.vcs.git");
+      getShell().execute("gitignore setup");
+      getShell().execute("gitignore list-templates");
+
+      // then
+      String listOutput = getOutput().substring(getOutput().indexOf("==="));
+      assertFalse(listOutput.contains(".gitignore"));
+      assertTrue(listOutput.contains("= Languages ="));
+      assertTrue(listOutput.contains("= Globals ="));
+      assertTrue(listOutput.contains("Java"));
+      assertTrue(listOutput.contains("Eclipse"));
+   }
+   
+   @Test
+   public void should_create_gitignore() throws Exception
+   {
+      // given
+      initializeJavaProject();
+      Resource<?> cloneFolder = cloneFolder();
+      queueInputLines(cloneFolder.getFullyQualifiedName(), "\n");
+
+      // when
+      getShell().execute("project install-facet forge.vcs.git");
+      getShell().execute("gitignore setup");
+      getShell().execute("gitignore create Eclipse Maven");
+
+      // then
+      GitIgnoreResource gitignore = gitIgnoreResource();
+      assertTrue(gitignore.exists());
+      String content = Streams.toString(gitignore.getResourceInputStream());
+      assertTrue(content.contains(".classpath"));
+      assertTrue(content.contains("target/"));
+   }
+   
+   @Test
+   public void should_add_pattern() throws Exception
+   {
+      // given
+      initializeJavaProject();
+      Resource<?> cloneFolder = cloneFolder();
+      queueInputLines(cloneFolder.getFullyQualifiedName(), "\n");
+
+      // when
+      getShell().execute("project install-facet forge.vcs.git");
+      getShell().execute("gitignore setup");
+      getShell().execute("gitignore create Eclipse");
+      getShell().execute("gitignore-edit add *.forge");
+
+      // then
+      String content = Streams.toString(gitIgnoreResource().getResourceInputStream());
+      assertTrue(content.contains("*.forge"));
+   }
+   
+   @Test
+   public void should_remove_pattern() throws Exception
+   {
+      // given
+      initializeJavaProject();
+      Resource<?> cloneFolder = cloneFolder();
+      queueInputLines(cloneFolder.getFullyQualifiedName(), "\n");
+
+      // when
+      getShell().execute("project install-facet forge.vcs.git");
+      getShell().execute("gitignore setup");
+      getShell().execute("gitignore create Eclipse");
+      getShell().execute("gitignore-edit remove .classpath");
+
+      // then
+      String content = Streams.toString(gitIgnoreResource().getResourceInputStream());
+      assertFalse(content.contains(".classpath"));
+   }
+
+   private GitIgnoreResource gitIgnoreResource()
+   {
+      return getProject().getProjectRoot()
+               .getChildOfType(GitIgnoreResource.class, ".gitignore");
+   }
+
+   private Resource<?> cloneFolder()
+   {
+      return getProject().getProjectRoot().getChildDirectory("gibo");
+   }
+
+}

--- a/git-tools/pom.xml
+++ b/git-tools/pom.xml
@@ -18,7 +18,7 @@
       <dependency>
          <groupId>org.eclipse.jgit</groupId>
          <artifactId>org.eclipse.jgit</artifactId>
-          <version>${jgit.version}</version>
+         <version>${jgit.version}</version>
       </dependency>
 
       <dependency>

--- a/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnore.java
+++ b/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnore.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.git.gitignore;
+
+import java.io.IOException;
+
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.jboss.forge.git.GitFacet;
+import org.jboss.forge.project.Project;
+import org.jboss.forge.project.facets.events.InstallFacets;
+import org.jboss.forge.project.services.ResourceFactory;
+import org.jboss.forge.resources.FileResource;
+import org.jboss.forge.shell.Shell;
+import org.jboss.forge.shell.ShellMessages;
+import org.jboss.forge.shell.ShellPrompt;
+import org.jboss.forge.shell.events.PickupResource;
+import org.jboss.forge.shell.plugins.Alias;
+import org.jboss.forge.shell.plugins.Command;
+import org.jboss.forge.shell.plugins.Help;
+import org.jboss.forge.shell.plugins.Option;
+import org.jboss.forge.shell.plugins.PipeOut;
+import org.jboss.forge.shell.plugins.Plugin;
+import org.jboss.forge.shell.plugins.RequiresFacet;
+import org.jboss.forge.shell.plugins.RequiresProject;
+import org.jboss.forge.shell.plugins.SetupCommand;
+
+/**
+ * Creates .gitignore files based on <a href="https://github.com/github/gitignore.git">GitHub templates</a>.
+ * Credits to the <a href="https://github.com/simonwhitaker/gitignore-boilerplates">gibo</a>
+ * shell script by Simon Whitaker for the idea.
+ * 
+ * @author <a href="mailto:thomas.hug@gmail.com">Thomas Hug</a>
+ */
+@Alias("gitignore")
+@Help("Creates .gitignore files based on template files from https://github.com/github/gitignore.git.")
+@RequiresProject
+@RequiresFacet({GitFacet.class, GitIgnoreFacet.class})
+public class GitIgnore implements Plugin
+{
+   @Inject
+   private GitIgnoreConfig config;
+   
+   @Inject
+   private Shell shell;
+   
+   @Inject
+   private ShellPrompt prompt;
+   
+   @Inject
+   private ResourceFactory factory;
+   
+   @Inject
+   private Event<InstallFacets> request;
+   
+   @Inject
+   private Event<PickupResource> pickUp;
+   
+   @Inject
+   private Project project;
+
+   @SetupCommand(help = "Clones the .gitignore template repository " +
+   		"into a local destination.")
+   public void setup() {
+      try
+      {
+         promptCloneDir();
+         promptRepository();
+         request.fire(new InstallFacets(GitIgnoreFacet.class));
+      }
+      catch (Exception e)
+      {
+         ShellMessages.error(shell, "Failed to create gitignore repository: " + e.getMessage());
+      }
+   }
+
+   @Command(value = "list-templates", help = "List all available .gitignore templates")
+   public void list(PipeOut out)
+   {
+      ShellMessages.info(shell, "Installed .gitignore templates:");
+      for (GitIgnoreTemplateGroup group : project.getFacet(GitIgnoreFacet.class).list())
+      {
+         out.println("============= " + group.getName() +  " =============");
+         for (String template : group.getTemplates())
+         {
+            out.println(template);
+         }
+      }
+   }
+   
+   @Command(value = "create", help = "Create a .gitignore from templates")
+   public void create(PipeOut out,
+            @Option(required = true,
+                    completer = GitIgnoreTemplateCompleter.class)
+            String... templates)
+   {
+      try
+      {
+         GitIgnoreFacet facet = project.getFacet(GitIgnoreFacet.class);
+         GitIgnoreResource resource = gitIgnoreResource();
+         StringBuffer buffer = new StringBuffer();
+         for (String template : templates)
+         {
+            String content = facet.contentOf(template);
+            buffer.append(content);
+         }
+         String content = buffer.toString();
+         resource.setContents(content);
+         ShellMessages.success(shell, "Wrote to .gitignore. Content:");
+         out.println(content);
+         pickUp.fire(new PickupResource(resource));
+      }
+      catch (Exception e)
+      {
+         ShellMessages.error(shell, "Failed writing .gitignore: " + e.getMessage());
+      }
+   }
+   
+   @Command(value = "update-repo", help = "Update the local template repository")
+   public void update()
+   {
+      try
+      {
+         project.getFacet(GitIgnoreFacet.class).update();
+         ShellMessages.success(shell, "Local gitignore repository updated.");
+      }
+      catch (IOException e)
+      {
+         ShellMessages.error(shell, "Error reading local repository: " + e.getMessage());
+      }
+      catch (GitAPIException e)
+      {
+         ShellMessages.error(shell, "Error pulling remote repository: " + e.getMessage());
+      }
+   }
+   
+   @Command(value = "edit", help = "Change the .gitignore file")
+   public void edit()
+   {
+      pickUp.fire(new PickupResource(gitIgnoreResource()));
+   }
+   
+   private void promptCloneDir()
+   {
+      FileResource<?> checkout = prompt.promptFile("Where should the gitignore" +
+            " template repository be installed at?", defaultDirectory());
+      if (checkout.exists()) {
+         validate(checkout);
+      } else {
+         checkout.mkdir();
+      }
+      config.setLocalRepository(checkout.getFullyQualifiedName());
+   }
+   
+   private void promptRepository()
+   {
+      String repo = prompt.prompt("Do you want to provide a different repository" +
+      		" location for gitignore templates?", config.defaultRemoteRepository());
+      config.setRemoteRepository(repo);
+   }
+
+   private FileResource<?> defaultDirectory()
+   {
+      return (FileResource<?>) factory.getResourceFrom(config.defaultLocalRepository());
+   }
+
+   private void validate(FileResource<?> clone)
+   {
+      if (!clone.isDirectory())
+      {
+         throw new IllegalArgumentException("File " + clone + " is not a directory.");
+      }
+      if (!clone.listResources().isEmpty())
+      {
+         throw new IllegalArgumentException("Directory " + clone + " is not empty");
+      }
+   }
+   
+   private GitIgnoreResource gitIgnoreResource()
+   {
+      GitIgnoreResource resource = project.getProjectRoot().getChildOfType(GitIgnoreResource.class, ".gitignore");
+      if (!resource.exists()) {
+         resource.createNewFile();
+      }
+      return resource;
+   }
+
+}

--- a/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreConfig.java
+++ b/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.git.gitignore;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.jboss.forge.env.Configuration;
+import org.jboss.forge.env.ConfigurationScope;
+
+public class GitIgnoreConfig
+{
+
+   private static final String CLONE_LOCATION_KEY = "gitignore.plugin.clone";
+   private static final String REPOSITORY_KEY = "gitignore.plugin.repo";
+
+   private static final String REPOSITORY = "https://github.com/github/gitignore.git";
+
+   @Inject
+   private Configuration config;
+
+   public String defaultRemoteRepository()
+   {
+      return REPOSITORY;
+   }
+
+   public String remoteRepository()
+   {
+      Configuration user = userConfig();
+      if (user.containsKey(REPOSITORY_KEY))
+      {
+         return user.getString(REPOSITORY_KEY);
+      }
+      return defaultRemoteRepository();
+   }
+   
+   public void setRemoteRepository(String repoUrl)
+   {
+      userConfig().setProperty(REPOSITORY_KEY, repoUrl);
+   }
+   
+   public File defaultLocalRepository()
+   {
+      return new File(System.getProperty("user.home") + File.separator + ".gitignore_boilerplate");
+   }
+   
+   public File localRepository()
+   {
+      Configuration user = userConfig();
+      if (user.containsKey(CLONE_LOCATION_KEY))
+      {
+         return new File(user.getString(CLONE_LOCATION_KEY));
+      }
+      return defaultLocalRepository();
+   }
+   
+   public void setLocalRepository(String location)
+   {
+      userConfig().setProperty(CLONE_LOCATION_KEY, location);
+   }
+
+   private Configuration userConfig()
+   {
+      return config.getScopedConfiguration(ConfigurationScope.USER);
+   }
+
+}

--- a/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreContent.java
+++ b/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreContent.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.git.gitignore;
+
+import javax.inject.Inject;
+
+import org.jboss.forge.project.Project;
+import org.jboss.forge.shell.Shell;
+import org.jboss.forge.shell.plugins.Alias;
+import org.jboss.forge.shell.plugins.Command;
+import org.jboss.forge.shell.plugins.Current;
+import org.jboss.forge.shell.plugins.Help;
+import org.jboss.forge.shell.plugins.Option;
+import org.jboss.forge.shell.plugins.PipeOut;
+import org.jboss.forge.shell.plugins.Plugin;
+import org.jboss.forge.shell.plugins.RequiresProject;
+import org.jboss.forge.shell.plugins.RequiresResource;
+
+/**
+ * @author Dan Allen
+ */
+@Alias("gitignore-edit")
+@Help("Manage the contents of .gitignore files")
+@RequiresProject
+@RequiresResource(GitIgnoreResource.class)
+public class GitIgnoreContent implements Plugin
+{
+
+   @Inject
+   @Current
+   private GitIgnoreResource gitIgnore;
+
+   @Inject
+   private Project project;
+
+   @Inject
+   private Shell shell;
+
+   @Command(help = "List the ignore patterns")
+   public void list(PipeOut out)
+   {
+      for (String pattern : gitIgnore.getPatterns())
+      {
+         out.println(pattern);
+      }
+   }
+
+   @Command(help = "Add ignore pattern")
+   public void add(@Option(description = "pattern", required = true) String pattern, PipeOut out)
+   {
+      gitIgnore.addPattern(pattern);
+      out.println("Pattern added to the .gitignore in the current directory");
+   }
+
+   @Command(help = "Remove ignore pattern")
+   public void remove(
+            @Option(description = "pattern", required = true, completer = GitIgnorePatternCompleter.class) String pattern,
+            PipeOut out)
+   {
+      gitIgnore.removePattern(pattern);
+      out.println("Pattern removed from the .gitignore in the current directory");
+   }
+
+}

--- a/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreEntry.java
+++ b/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreEntry.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.git.gitignore;
+
+/**
+ * @author Dan Allen
+ */
+public class GitIgnoreEntry
+{
+   private String content;
+   private boolean pattern;
+   private boolean comment;
+   private boolean negate;
+
+   public GitIgnoreEntry(String line)
+   {
+      if (line.startsWith("!"))
+      {
+         this.content = line.substring(1);
+         this.pattern = true;
+         this.negate = true;
+      }
+      else if (line.startsWith("#"))
+      {
+         this.content = line.substring(1).trim();
+         this.comment = true;
+      }
+      else if (line.length() > 0)
+      {
+         this.content = line;
+         this.pattern = true;
+      }
+   }
+
+   public GitIgnoreEntry(String content, boolean pattern, boolean negate)
+   {
+      this.content = content;
+      this.pattern = pattern;
+      this.negate = negate;
+   }
+
+   public String getContent()
+   {
+      return content;
+   }
+
+   public boolean isPattern()
+   {
+      return pattern;
+   }
+
+   public boolean isComment()
+   {
+      return comment;
+   }
+
+   public boolean isNegate()
+   {
+      return negate;
+   }
+
+   public boolean isBlank()
+   {
+      return content != null;
+   }
+
+   @Override
+   public int hashCode()
+   {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + (comment ? 1231 : 1237);
+      result = prime * result + ((content == null) ? 0 : content.hashCode());
+      result = prime * result + (negate ? 1231 : 1237);
+      result = prime * result + (pattern ? 1231 : 1237);
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object obj)
+   {
+      if (this == obj)
+      {
+         return true;
+      }
+      if (obj == null)
+      {
+         return false;
+      }
+      if (getClass() != obj.getClass())
+      {
+         return false;
+      }
+      GitIgnoreEntry other = (GitIgnoreEntry) obj;
+      if (comment != other.comment)
+      {
+         return false;
+      }
+      if (content == null)
+      {
+         if (other.content != null)
+         {
+            return false;
+         }
+      }
+      else if (!content.equals(other.content))
+      {
+         return false;
+      }
+      if (negate != other.negate)
+      {
+         return false;
+      }
+      if (pattern != other.pattern)
+      {
+         return false;
+      }
+      return true;
+   }
+
+   public String toString()
+   {
+      if (content == null)
+      {
+         return "";
+      }
+      else if (comment)
+      {
+         return "# " + content;
+      }
+      else if (negate)
+      {
+         return "!" + content;
+      }
+      else
+      {
+         return content;
+      }
+   }
+
+}

--- a/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreFacet.java
+++ b/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreFacet.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.git.gitignore;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.jboss.forge.git.GitFacet;
+import org.jboss.forge.git.GitUtils;
+import org.jboss.forge.project.facets.BaseFacet;
+import org.jboss.forge.project.services.ResourceFactory;
+import org.jboss.forge.resources.DirectoryResource;
+import org.jboss.forge.resources.FileResource;
+import org.jboss.forge.resources.Resource;
+import org.jboss.forge.resources.ResourceFilter;
+import org.jboss.forge.shell.Shell;
+import org.jboss.forge.shell.ShellMessages;
+import org.jboss.forge.shell.plugins.Alias;
+import org.jboss.forge.shell.plugins.RequiresFacet;
+import org.jboss.forge.shell.util.Streams;
+
+@Alias("forge.vcs.git.ignore")
+@RequiresFacet(GitFacet.class)
+public class GitIgnoreFacet extends BaseFacet
+{
+   public static final String GITIGNORE = ".gitignore";
+
+   private static final String GLOBAL_TEMPLATES = "Global";
+
+   @Inject
+   private GitIgnoreConfig config;
+
+   @Inject
+   private ResourceFactory factory;
+
+   @Inject
+   private Shell shell;
+
+   @Override
+   public boolean install()
+   {
+      try
+      {
+         DirectoryResource cloneDir = cloneDir();
+         String repo = config.remoteRepository();
+         ShellMessages.info(shell, "Cloning " + repo + " into " + cloneDir.getFullyQualifiedName());
+         GitUtils.clone(cloneDir, repo);
+         return true;
+      }
+      catch (Exception e)
+      {
+         ShellMessages.error(shell, "Failed to checkout gitignore: " + e);
+         return false;
+      }
+   }
+
+   @Override
+   public boolean isInstalled()
+   {
+      File clone = config.localRepository();
+      Resource<File> cloneDir = factory.getResourceFrom(clone);
+      return cloneDir.exists() && cloneDir.getChild(".git").exists();
+   }
+
+   /**
+    * List all available gitignore templates.
+    */
+   public List<GitIgnoreTemplateGroup> list()
+   {
+      List<GitIgnoreTemplateGroup> result = new ArrayList<GitIgnoreTemplateGroup>(2);
+      DirectoryResource languages = cloneDir();
+      result.add(new GitIgnoreTemplateGroup("Languages", listGitignores(languages)));
+      result.add(new GitIgnoreTemplateGroup("Globals", listGitignores(languages.getChildDirectory(GLOBAL_TEMPLATES))));
+      return result;
+   }
+
+   /**
+    * Read the content of a gitignore template
+    * 
+    * @param template Template name.
+    * @return Template content as string.
+    */
+   @SuppressWarnings("unchecked")
+   public String contentOf(String template)
+   {
+      DirectoryResource[] candidates = new DirectoryResource[] {
+               cloneDir(), cloneDir().getChildDirectory(GLOBAL_TEMPLATES)
+      };
+      for (DirectoryResource dir : candidates)
+      {
+         if (listGitignores(dir).contains(template))
+         {
+            FileResource<?> file = dir.getChildOfType(FileResource.class, template + GITIGNORE);
+            return Streams.toString(file.getResourceInputStream());
+         }
+      }
+      return "";
+   }
+
+   /**
+    * Update the templates from the remote repository.
+    * 
+    * @throws IOException Failure reading the git repository.
+    * @throws GitAPIException Git failure.
+    */
+   public void update() throws IOException, GitAPIException
+   {
+      GitUtils.pull(GitUtils.git(cloneDir()), 10000);
+   }
+
+   private List<String> listGitignores(DirectoryResource dir)
+   {
+      List<String> result = new LinkedList<String>();
+      ResourceFilter filter = new ResourceFilter()
+      {
+         @Override
+         public boolean accept(Resource<?> resource)
+         {
+            return resource.getName().endsWith(GITIGNORE);
+         }
+      };
+      for (Resource<?> resource : dir.listResources(filter))
+      {
+         String name = resource.getName();
+         String cut = name.substring(0, name.indexOf(GITIGNORE));
+         result.add(cut);
+      }
+      return result;
+   }
+
+   private DirectoryResource cloneDir()
+   {
+      return new DirectoryResource(factory, config.localRepository());
+   }
+
+}

--- a/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnorePatternCompleter.java
+++ b/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnorePatternCompleter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.git.gitignore;
+
+import javax.inject.Inject;
+
+import org.jboss.forge.shell.completer.SimpleTokenCompleter;
+import org.jboss.forge.shell.plugins.Current;
+
+/**
+ * @author Dan Allen
+ */
+public class GitIgnorePatternCompleter extends SimpleTokenCompleter
+{
+
+   @Inject
+   @Current
+   private GitIgnoreResource resource;
+
+   @Override
+   public Iterable<?> getCompletionTokens()
+   {
+      return resource.getPatterns();
+   }
+
+}

--- a/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnorePatternResource.java
+++ b/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnorePatternResource.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.git.gitignore;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.forge.resources.Resource;
+import org.jboss.forge.resources.VirtualResource;
+
+/**
+ * @author Dan Allen
+ */
+public class GitIgnorePatternResource extends VirtualResource<String>
+{
+
+   private String pattern;
+
+   protected GitIgnorePatternResource(Resource<?> parent, String pattern)
+   {
+      super(parent);
+      this.pattern = pattern;
+   }
+
+   @Override
+   public boolean delete() throws UnsupportedOperationException
+   {
+      throw new UnsupportedOperationException("Not implemented");
+   }
+
+   @Override
+   public boolean delete(boolean recursive)
+            throws UnsupportedOperationException
+   {
+      throw new UnsupportedOperationException("Recursive deletion does not apply");
+   }
+
+   @Override
+   public String getName()
+   {
+      return pattern;
+   }
+
+   @Override
+   public String getUnderlyingResourceObject()
+   {
+      return pattern;
+   }
+
+   @Override
+   protected List<Resource<?>> doListResources()
+   {
+      return Collections.emptyList();
+   }
+
+   @Override
+   public String toString()
+   {
+      return getName();
+   }
+}

--- a/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreResource.java
+++ b/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreResource.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.git.gitignore;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.jboss.forge.project.services.ResourceFactory;
+import org.jboss.forge.resources.FileResource;
+import org.jboss.forge.resources.Resource;
+import org.jboss.forge.resources.ResourceFlag;
+import org.jboss.forge.resources.ResourceHandles;
+import org.jboss.forge.shell.util.Streams;
+
+/**
+ * @author Dan Allen
+ */
+@ResourceHandles(GitIgnoreResource.RESOURCE_NAME)
+public class GitIgnoreResource extends FileResource<GitIgnoreResource>
+{
+
+   public static final String RESOURCE_NAME = ".gitignore";
+
+   @Inject
+   public GitIgnoreResource(ResourceFactory factory)
+   {
+      this(factory, null);
+   }
+
+   protected GitIgnoreResource(ResourceFactory factory, File file)
+   {
+      super(factory, file);
+      setFlag(ResourceFlag.File);
+   }
+
+   @Override
+   public Resource<File> createFrom(File file)
+   {
+      return new GitIgnoreResource(getResourceFactory(), file);
+   }
+
+   @Override
+   protected List<Resource<?>> doListResources()
+   {
+      List<Resource<?>> patterns = new ArrayList<Resource<?>>();
+      for (GitIgnoreEntry entry : getEntries())
+      {
+         if (entry.isPattern())
+         {
+            patterns.add(new GitIgnorePatternResource(this, entry.getContent()));
+         }
+      }
+      return patterns;
+   }
+
+   public void addPattern(String pattern)
+   {
+      List<GitIgnoreEntry> entries = getEntries();
+      GitIgnoreEntry entry = new GitIgnoreEntry(pattern);
+      if (!entries.contains(entry))
+      {
+         entries.add(entry);
+         storeEntries(entries);
+      }
+   }
+
+   public void addPatterns(String[] newPatterns)
+   {
+      List<GitIgnoreEntry> entries = getEntries();
+      boolean modified = false;
+      for (String pattern : newPatterns)
+      {
+         GitIgnoreEntry entry = new GitIgnoreEntry(pattern);
+         if (entries.contains(entry))
+         {
+            entries.add(entry);
+            modified = true;
+         }
+      }
+      if (modified)
+      {
+         storeEntries(entries);
+      }
+   }
+
+   public void removePattern(String pattern)
+   {
+      List<GitIgnoreEntry> entries = getEntries();
+      GitIgnoreEntry entry = new GitIgnoreEntry(pattern);
+      if (entries.contains(entry))
+      {
+         entries.remove(entry);
+         storeEntries(entries);
+      }
+   }
+
+   public List<String> getPatterns()
+   {
+      List<String> patterns = new ArrayList<String>();
+      for (GitIgnoreEntry entry : getEntries())
+      {
+         if (entry.isPattern())
+         {
+            patterns.add(entry.toString());
+         }
+      }
+      return patterns;
+   }
+
+   public List<GitIgnoreEntry> getEntries()
+   {
+      List<GitIgnoreEntry> lines = new ArrayList<GitIgnoreEntry>();
+      BufferedReader reader = null;
+      try
+      {
+         reader = new BufferedReader(new InputStreamReader(getResourceInputStream()));
+         String line = null;
+         while ((line = reader.readLine()) != null)
+         {
+            lines.add(new GitIgnoreEntry(line));
+         }
+         return lines;
+      }
+      catch (IOException e)
+      {
+         throw new RuntimeException(
+                  "Error while reading .gitignore patterns", e);
+      }
+      finally
+      {
+         Streams.closeQuietly(reader);
+      }
+   }
+
+   protected void storeEntries(List<GitIgnoreEntry> entries)
+   {
+      StringBuilder contents = new StringBuilder();
+      for (GitIgnoreEntry entry : entries)
+      {
+         contents.append(entry.toString()).append("\n");
+      }
+      setContents(contents.toString());
+   }
+
+}

--- a/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreTemplateCompleter.java
+++ b/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreTemplateCompleter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.git.gitignore;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+import javax.inject.Inject;
+
+import org.jboss.forge.parser.java.util.Strings;
+import org.jboss.forge.project.Project;
+import org.jboss.forge.shell.Shell;
+import org.jboss.forge.shell.completer.CommandCompleter;
+import org.jboss.forge.shell.completer.CommandCompleterState;
+
+public class GitIgnoreTemplateCompleter implements CommandCompleter
+{
+
+   @Inject
+   private Project project;
+   
+   @Inject
+   private Shell shell;
+
+   @Override
+   public void complete(CommandCompleterState state)
+   {
+      Queue<String> tokens = state.getTokens();
+      String peek = tokens.peek();
+      List<String> candidates = candidates(peek);
+      if (!candidates.isEmpty())
+      {
+         if (!Strings.isNullOrEmpty(peek))
+         {
+            state.setIndex(state.getBuffer().lastIndexOf(peek));
+         }
+         state.getCandidates().addAll(candidates);
+      }
+   }
+   
+   private List<String> candidates(String start)
+   {
+      List<String> result = new LinkedList<String>();
+      for (GitIgnoreTemplateGroup group : project.getFacet(GitIgnoreFacet.class).list())
+      {
+         for (String template : group.getTemplates())
+         {
+            if (Strings.isNullOrEmpty(start) || template.startsWith(start))
+            {
+               result.add(template);
+            }
+         }
+      }
+      return result;
+   }
+
+}

--- a/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreTemplateGroup.java
+++ b/git-tools/src/main/java/org/jboss/forge/git/gitignore/GitIgnoreTemplateGroup.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.git.gitignore;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class GitIgnoreTemplateGroup
+{
+
+   private final String name;
+   private final List<String> templates;
+
+   public GitIgnoreTemplateGroup(String name)
+   {
+      this(name, new LinkedList<String>());
+      
+   }
+   
+   public GitIgnoreTemplateGroup(String name, List<String> templates)
+   {
+      this.name = name;
+      this.templates = templates;
+   }
+   
+   public void add(String template)
+   {
+      templates.add(template);
+   }
+
+   public String getName()
+   {
+      return name;
+   }
+
+   public List<String> getTemplates()
+   {
+      return templates;
+   }
+   
+}

--- a/git-tools/src/main/java/org/jboss/forge/git/gitignore/LsGitIgnore.java
+++ b/git-tools/src/main/java/org/jboss/forge/git/gitignore/LsGitIgnore.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.git.gitignore;
+
+import org.jboss.forge.resources.Resource;
+import org.jboss.forge.shell.plugins.Alias;
+import org.jboss.forge.shell.plugins.DefaultCommand;
+import org.jboss.forge.shell.plugins.Help;
+import org.jboss.forge.shell.plugins.Option;
+import org.jboss.forge.shell.plugins.PipeOut;
+import org.jboss.forge.shell.plugins.Plugin;
+import org.jboss.forge.shell.plugins.RequiresResource;
+import org.jboss.forge.shell.plugins.Topic;
+
+/**
+ * @author Dan Allen
+ */
+@Alias("ls")
+@RequiresResource(GitIgnoreResource.class)
+@Topic("Files & Resources")
+@Help("Prints the contents of the current gitignore file")
+public class LsGitIgnore implements Plugin
+{
+
+   @DefaultCommand
+   public void ls(@Option(description = "path", defaultValue = ".") final Resource<?> resource, PipeOut out)
+   {
+      for (String pattern : ((GitIgnoreResource) resource).getPatterns())
+      {
+         out.println(pattern);
+      }
+   }
+
+}


### PR DESCRIPTION
Usage:

```
git init
gitignore setup
```

Prompts for alternative installation / clone location of the gitignore template repository. Both values go into the user configuration.

```
gitignore list-templates
```

Shows all available templates.

```
gitignore create template1 template2 ...
```

Creates the .gitignore with the given templates (tab support). Sends a pickup event with the GitIgnoreResource, enabling the GitIgnoreContent plugin by Dan. I guess Forge 2 will allow to combine both plugins with @RequiresResource on commands.

```
gitignore-edit list
gitignore-edit add pattern
gitignore-edit remove pattern
```

To enter edit mode at a later stage:

```
gitignore edit
```
