### PR TITLE
Support exclusions on plugin dependencies

### DIFF
--- a/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPluginImpl.java
+++ b/maven-api/src/main/java/org/jboss/forge/maven/plugins/MavenPluginImpl.java
@@ -15,117 +15,163 @@ import org.jboss.forge.project.dependencies.Dependency;
 /**
  * @author <a href="mailto:paul.bakker.nl@gmail.com">Paul Bakker</a>
  */
-public class MavenPluginImpl implements MavenPlugin {
-   
-    private Dependency dependency;
-    private Configuration configuration;
-    private final List<Execution> executions = new ArrayList<Execution>();
-    private boolean extensions;
-    private List<Dependency> pluginDependencies = new ArrayList<Dependency>();
+public class MavenPluginImpl implements MavenPlugin
+{
 
-    public MavenPluginImpl() {
-    }
+   private Dependency dependency;
+   private Configuration configuration;
+   private final List<Execution> executions = new ArrayList<Execution>();
+   private boolean extensions;
+   private List<Dependency> pluginDependencies = new ArrayList<Dependency>();
 
-    public MavenPluginImpl(final MavenPlugin plugin) {
-        this.dependency = plugin.getDependency();
-        this.configuration = plugin.getConfig();
-    }
+   public MavenPluginImpl()
+   {
+   }
 
-    @Override
-    public Dependency getDependency() {
-        return dependency;
-    }
+   public MavenPluginImpl(final MavenPlugin plugin)
+   {
+      this.dependency = plugin.getDependency();
+      this.configuration = plugin.getConfig();
+   }
 
-    public void setDependency(final Dependency dependency) {
-        this.dependency = dependency;
-    }
+   @Override
+   public Dependency getDependency()
+   {
+      return dependency;
+   }
 
-    @Override
-    public Configuration getConfig() {
-        if (configuration == null) {
-            configuration = ConfigurationBuilder.create();
-        }
-        return configuration;
-    }
+   public void setDependency(final Dependency dependency)
+   {
+      this.dependency = dependency;
+   }
 
-    @Override
-    public List<Execution> listExecutions() {
-        return executions;
-    }
+   @Override
+   public Configuration getConfig()
+   {
+      if (configuration == null)
+      {
+         configuration = ConfigurationBuilder.create();
+      }
+      return configuration;
+   }
 
-    @Override
-    public boolean isExtensionsEnabled() {
-        return extensions;
-    }
-    
-    @Override
-    public List<Dependency> getDirectDependencies() {
-       return pluginDependencies;
-    }
+   @Override
+   public List<Execution> listExecutions()
+   {
+      return executions;
+   }
 
-    @Override
-    public String toString() {
-        StringBuilder b = new StringBuilder("<plugin>");
-        appendDependency(b, dependency);
+   @Override
+   public boolean isExtensionsEnabled()
+   {
+      return extensions;
+   }
 
-        if(extensions) {
-            b.append("<extensions>true</extensions>");
-        }
+   @Override
+   public List<Dependency> getDirectDependencies()
+   {
+      return pluginDependencies;
+   }
 
-        if (configuration != null) {
-            b.append(configuration.toString());
-        }
+   @Override
+   public String toString()
+   {
+      StringBuilder b = new StringBuilder("<plugin>");
+      appendDependency(b, dependency);
 
-        if (executions.size() > 0) {
-            b.append("<executions>");
-            for (Execution execution : executions) {
-                b.append(execution.toString());
-            }
-            b.append("</executions>");
-        }
-        
-        if (pluginDependencies.size() > 0) {
-           b.append("<dependencies>");
-           for (Dependency pluginDependency : pluginDependencies) {
-               b.append("<dependency>");
-               appendDependency(b, pluginDependency);
-               b.append("</dependency>");
-           }
-           b.append("</dependencies>");
-       }
-
-        b.append("</plugin>");
-        return b.toString();
-    }
-
-    public void setConfiguration(final Configuration configuration) {
-        this.configuration = configuration;
-    }
-
-    public void addExecution(final Execution execution) {
-        executions.add(execution);
-    }
-
-    public void setExtenstions(boolean extenstions) {
-        this.extensions = extenstions;
-    }
-    
-    public void addPluginDependency(final Dependency dependency) {
-       pluginDependencies.add(dependency);
-    }
-    
-    private void appendDependency(StringBuilder buffer, Dependency appendDependency) {
-       if (appendDependency.getGroupId() != null) {
-          buffer.append("<groupId>").append(appendDependency.getGroupId()).append("</groupId>");
+      if (extensions)
+      {
+         b.append("<extensions>true</extensions>");
       }
 
-      if (appendDependency.getArtifactId() != null) {
-         buffer.append("<artifactId>").append(appendDependency.getArtifactId()).append("</artifactId>");
+      if (configuration != null)
+      {
+         b.append(configuration.toString());
       }
 
-      if (appendDependency.getVersion() != null) {
-         buffer.append("<version>").append(appendDependency.getVersion()).append("</version>");
+      if (executions.size() > 0)
+      {
+         b.append("<executions>");
+         for (Execution execution : executions)
+         {
+            b.append(execution.toString());
+         }
+         b.append("</executions>");
       }
-    }
+
+      if (pluginDependencies.size() > 0)
+      {
+         b.append("<dependencies>");
+         for (Dependency pluginDependency : pluginDependencies)
+         {
+            b.append("<dependency>");
+            appendDependency(b, pluginDependency);
+            b.append("</dependency>");
+         }
+         b.append("</dependencies>");
+      }
+
+      b.append("</plugin>");
+      return b.toString();
+   }
+
+   public void setConfiguration(final Configuration configuration)
+   {
+      this.configuration = configuration;
+   }
+
+   public void addExecution(final Execution execution)
+   {
+      executions.add(execution);
+   }
+
+   public void setExtenstions(boolean extenstions)
+   {
+      this.extensions = extenstions;
+   }
+
+   public void addPluginDependency(final Dependency dependency)
+   {
+      pluginDependencies.add(dependency);
+   }
+
+   private void appendDependency(StringBuilder builder, Dependency appendDependency)
+   {
+      appendDependencyData(builder, appendDependency, true);
+      if (!appendDependency.getExcludedDependencies().isEmpty())
+      {
+         builder.append("<exclusions>");
+         for (Dependency exclusion : appendDependency.getExcludedDependencies())
+         {
+            appendExclusion(builder, exclusion);
+         }
+         builder.append("</exclusions>");
+      }
+   }
+
+   private void appendExclusion(StringBuilder builder, Dependency exclusion)
+   {
+      builder.append("<exclusion>");
+      appendDependencyData(builder, exclusion, false);
+      builder.append("</exclusion>");
+   }
+
+   private void appendDependencyData(StringBuilder builder, Dependency dependency, boolean withVersion)
+   {
+      if (dependency.getGroupId() != null)
+      {
+         builder.append("<groupId>").append(dependency.getGroupId()).append("</groupId>");
+      }
+
+      if (dependency.getArtifactId() != null)
+      {
+         builder.append("<artifactId>").append(dependency.getArtifactId()).append("</artifactId>");
+      }
+
+      if (withVersion && dependency.getVersion() != null)
+      {
+         builder.append("<version>").append(dependency.getVersion()).append("</version>");
+      }
+   }
 
 }

--- a/maven-api/src/test/java/org/jboss/forge/maven/plugins/MavenPluginAdapterTest.java
+++ b/maven-api/src/test/java/org/jboss/forge/maven/plugins/MavenPluginAdapterTest.java
@@ -1,0 +1,132 @@
+package org.jboss.forge.maven.plugins;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+
+import org.apache.maven.model.Exclusion;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.jboss.forge.project.dependencies.Dependency;
+import org.jboss.forge.project.dependencies.DependencyBuilder;
+import org.junit.Test;
+
+public class MavenPluginAdapterTest
+{
+
+   @Test
+   public void should_transform_simple_plugin()
+   {
+      // given
+      Dependency compiler = mavenCompilerPlugin();
+      MavenPluginBuilder builder = MavenPluginBuilder.create()
+               .setDependency(compiler);
+      
+      // when
+      Plugin plugin = new MavenPluginAdapter(builder);
+      
+      // then
+      assertEquals(compiler.getGroupId(), plugin.getGroupId());
+      assertEquals(compiler.getArtifactId(), plugin.getArtifactId());
+      assertEquals(compiler.getVersion(), plugin.getVersion());
+      assertNull(plugin.getExtensions());
+   }
+   
+   @Test
+   public void should_transform_plugin_with_configuration()
+   {
+      // given
+      MavenPluginBuilder builder = MavenPluginBuilder.create()
+               .setDependency(mavenCompilerPlugin())
+               .setConfiguration(
+                        ConfigurationBuilder.create()
+                                 .addConfigurationElement(ConfigurationElementBuilder.create()
+                                          .addChild("test").setText("content")));
+      
+      // when
+      Plugin plugin = new MavenPluginAdapter(builder);
+      
+      // then
+      assertNotNull(plugin.getConfiguration());
+      assertNotNull(((Xpp3Dom) plugin.getConfiguration()).getChild("test"));
+   }
+   
+   @Test
+   public void should_transform_plugin_with_extension()
+   {
+      // given
+      MavenPluginBuilder builder = MavenPluginBuilder.create()
+               .setDependency(mavenCompilerPlugin())
+               .setExtensions(true);
+      // when
+      Plugin plugin = new MavenPluginAdapter(builder);
+      
+      // then
+      assertNotNull(plugin.getExtensions());
+   }
+   
+   @Test
+   public void should_transform_plugin_with_dependencies()
+   {
+      // given
+      MavenPluginBuilder builder = MavenPluginBuilder.create()
+               .setDependency(mavenCompilerPlugin())
+               .addPluginDependency(groovyCompiler());
+      
+      // when
+      Plugin plugin = new MavenPluginAdapter(builder);
+      
+      // then
+      List<org.apache.maven.model.Dependency> dependencies = plugin.getDependencies();
+      assertNotNull(dependencies);
+      assertEquals(1, dependencies.size());
+      org.apache.maven.model.Dependency dependency = dependencies.get(0);
+      assertEquals("groovy-eclipse-compiler", dependency.getArtifactId());
+      assertEquals("org.codehaus.groovy", dependency.getGroupId());
+      assertEquals("2.7.0-01", dependency.getVersion());
+      List<Exclusion> exclusions = dependency.getExclusions();
+      assertFalse(exclusions.isEmpty());
+      assertEquals("groovy-all", exclusions.get(0).getArtifactId());
+   }
+   
+   @Test
+   public void should_transform_plugin_with_executions()
+   {
+      // given
+      MavenPluginBuilder builder = MavenPluginBuilder.create()
+               .setDependency(mavenCompilerPlugin())
+               .addExecution(ExecutionBuilder.create()
+                        .addGoal("test")
+                        .setId("testId")
+                        .setPhase("test"));
+      
+      // when
+      Plugin plugin = new MavenPluginAdapter(builder);
+      
+      // then
+      assertFalse(plugin.getExecutions().isEmpty());
+      PluginExecution execution = plugin.getExecutions().get(0);
+      assertEquals("testId", execution.getId());
+      assertFalse(execution.getGoals().isEmpty());
+   }
+   
+   private Dependency groovyCompiler()
+   {
+      DependencyBuilder builder = DependencyBuilder.create(
+            "org.codehaus.groovy:groovy-eclipse-compiler:2.7.0-01");
+      builder.addExclusion()
+            .setArtifactId("groovy-all")
+            .setGroupId("org.codehaus.groovy");
+      return builder;
+   }
+
+   private Dependency mavenCompilerPlugin()
+   {
+      return DependencyBuilder.create(
+               "org.apache.maven.plugins:maven-compiler-plugin");
+   }
+}


### PR DESCRIPTION
This would allow creating something like

```
<plugin>
  <artifactId>maven-compiler-plugin</artifactId>
  <dependencies>
    <dependency>
      <groupId>org.codehaus.groovy</groupId>
      <artifactId>groovy-eclipse-compiler</artifactId>
      <exclusions>
        <exclusion>
          <groupId>org.codehaus.groovy</groupId>
          <artifactId>groovy-all</artifactId>
        </exclusion>
      </exclusions>
    </dependency>
    ...
```
