### PR TITLE
FORGE-727 Fix for unexpected operator error message

### DIFF
--- a/dist/src/main/resources/bin/forge
+++ b/dist/src/main/resources/bin/forge
@@ -27,15 +27,15 @@ FORGE_DEBUG_ARGS=""
 QUOTED_ARGS=""
 while [ "$1" != "" ] ; do
 
-  if [ "$PLUGIN_DIR" == "-pluginDir" ] ; then
+  if [ "$PLUGIN_DIR" = "-pluginDir" ] ; then
     PLUGIN_DIR="$1"
   fi
 
-  if [ "$1" == "-pluginDir" ] ; then
+  if [ "$1" = "-pluginDir" ] ; then
     PLUGIN_DIR="-pluginDir"
   fi
 
-  if [ "$1" == "--debug" ] ; then
+  if [ "$1" = "--debug" ] ; then
     FORGE_DEBUG_ARGS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000"
   fi
 


### PR DESCRIPTION
Ubuntu and other Debian based derivates use dash instead of bash
to execute scripts requiring /bin/sh. The POSIX sh aka dash shell
 does not understand "==".

Hence using "=" instead in the forge script.
