### PR TITLE
ensure the shell script reaches the bin directory in *nix format

### DIFF
--- a/dist/build.xml
+++ b/dist/build.xml
@@ -38,6 +38,7 @@
 				<include name="**/*" />
 			</fileset>
 		</chmod>
+		<fixcrlf file="${output.dir}/bin/forge" eol="unix" />
 	</target>
 
 	<target name="make-dirs">


### PR DESCRIPTION
Not sure this is large enough to warrant a JIRA issue; also the cygwin terminal doesn't play nice, but this change at least allows the shell script to run under cygwin without the user having to execute d2u.
