### PR TITLE
[FORGE-788] Add support for Updating Maven Pom Dependencies

### DIFF
--- a/dev-plugins/src/main/java/org/jboss/forge/dev/mvn/MavenPlugin.java
+++ b/dev-plugins/src/main/java/org/jboss/forge/dev/mvn/MavenPlugin.java
@@ -9,6 +9,7 @@ package org.jboss.forge.dev.mvn;
 
 import java.util.List;
 
+import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 
 import org.apache.maven.model.Model;
@@ -49,15 +50,17 @@ public class MavenPlugin implements Plugin
    private final Project project;
    private final ProjectFactory factory;
    private final ResourceFactory resources;
+   private final BeanManager manager;
 
    @Inject
    public MavenPlugin(final Shell shell, final Project project, final ProjectFactory factory,
-            final ResourceFactory resources)
+            final ResourceFactory resources, BeanManager manager)
    {
       this.shell = shell;
       this.project = project;
       this.factory = factory;
       this.resources = resources;
+      this.manager = manager;
    }
 
    @Command("set-groupid")
@@ -229,6 +232,14 @@ public class MavenPlugin implements Plugin
       else
       {
          out.println("Nothing to remove...");
+      }
+   }
+   
+   @Command("update") 
+   public void updateDependencies()
+   {
+      if(!new VersionUpdater(project, shell, this.factory, manager).update()) {
+         shell.println("No nothing to update");
       }
    }
 }

--- a/dev-plugins/src/main/java/org/jboss/forge/dev/mvn/VersionUpdater.java
+++ b/dev-plugins/src/main/java/org/jboss/forge/dev/mvn/VersionUpdater.java
@@ -1,0 +1,293 @@
+package org.jboss.forge.dev.mvn;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Profile;
+import org.jboss.forge.maven.MavenCoreFacet;
+import org.jboss.forge.maven.dependencies.MavenDependencyAdapter;
+import org.jboss.forge.project.Project;
+import org.jboss.forge.project.dependencies.DependencyBuilder;
+import org.jboss.forge.project.dependencies.events.UpdatedDependency;
+import org.jboss.forge.project.dependencies.events.UpdatingDependency;
+import org.jboss.forge.project.facets.DependencyFacet;
+import org.jboss.forge.project.services.ProjectFactory;
+import org.jboss.forge.shell.Shell;
+import org.jboss.forge.shell.ShellColor;
+
+public class VersionUpdater
+{
+   private Project project;
+   private Shell shell;
+   private ProjectFactory projectFactory;
+   private BeanManager manager;
+   
+   public VersionUpdater(Project project, Shell shell, ProjectFactory projectFactory, BeanManager manager)
+   {
+      this.project = project;
+      this.shell = shell;
+      this.projectFactory = projectFactory;
+      this.manager = manager;
+   }
+   
+   public boolean update()
+   {
+      return update(project);
+   }
+   
+   private Properties[] append(Properties[] parent, Properties... children)
+   {
+      List<Properties> result = new ArrayList<Properties>();
+      if(children!= null)
+      {
+         result.addAll(Arrays.asList(children));
+      }
+      if(parent != null)
+      {
+         result.addAll(Arrays.asList(parent));
+      }
+      return result.toArray(new Properties[0]);
+   }
+   
+   public boolean update(Project currentProject, Properties... parentProperties)
+   {
+      boolean updated = false;
+      MavenCoreFacet mavenFacet = currentProject.getFacet(MavenCoreFacet.class);
+      DependencyFacet depFacet = currentProject.getFacet(DependencyFacet.class);
+      
+      Model pom = mavenFacet.getPOM();
+      
+      for(Dependency dependency : pom.getDependencies())
+      {
+         if(updateDependency(depFacet, dependency, append(parentProperties, pom.getProperties())))
+         {
+            mavenFacet.setPOM(pom);
+            updated = true;
+         }
+      }
+      if(pom.getDependencyManagement() != null)
+      {
+         for(Dependency dependency : pom.getDependencyManagement().getDependencies())
+         {
+            if(updateDependency(depFacet, dependency, append(parentProperties, pom.getProperties())))
+            {
+               mavenFacet.setPOM(pom);
+               updated = true;
+            }
+         }
+      }
+      for(Profile profile : pom.getProfiles())
+      {
+         for(Dependency dependency : profile.getDependencies())
+         {
+            if(updateDependency(depFacet, dependency, append(parentProperties, profile.getProperties(), pom.getProperties())))
+            {
+               mavenFacet.setPOM(pom);
+               updated = true;
+            }
+         }
+         if(profile.getDependencyManagement() != null)
+         {
+            for(Dependency dependency : profile.getDependencyManagement().getDependencies())
+            {
+               if(updateDependency(depFacet, dependency, append(parentProperties, profile.getProperties(), pom.getProperties())))
+               {
+                  mavenFacet.setPOM(pom);
+                  updated = true;
+               }
+            }
+         }
+      }
+      for(String module : pom.getModules())
+      {
+         Project subProject = projectFactory.findProject(
+               currentProject.getProjectRoot().getChildDirectory(module));
+         
+         if(update(subProject, append(parentProperties, pom.getProperties()))) {
+            mavenFacet.setPOM(pom);
+            updated = true;
+         }
+      }
+      return updated;
+   }
+
+   private boolean updateDependency(DependencyFacet depFacet, Dependency dependency, Properties... propertySets)
+   {
+      if(dependency.getVersion() == null)
+      {
+         return false; // managed ?
+      }
+      String propertyName = getExpressionName(dependency.getVersion());
+      if(isExpression(dependency.getVersion()))
+      {
+         boolean propertyFound = false;
+         for(Properties properties: propertySets)
+         {
+            if(properties.containsKey(propertyName))
+            {
+               propertyFound = true;
+            }
+         }
+         if(!propertyFound)
+         {
+            shell.println(
+                  "Can not update dependency with expression located in different pom: " + propertyName);
+            shell.println("\t" + dependency);
+            
+            return false;
+         }
+      }
+
+      String version = findNewerVersions(depFacet, dependency);
+      if(version != null)
+      {
+         org.jboss.forge.project.dependencies.Dependency from = depFacet.resolveProperties(
+               new MavenDependencyAdapter(dependency));
+         
+         org.jboss.forge.project.dependencies.Dependency to = DependencyBuilder.create(
+               depFacet.resolveProperties(
+                     new MavenDependencyAdapter(dependency)
+               )).setVersion(version);
+               
+         UpdatingDependency preEvent = new UpdatingDependency(
+               project, from, to);
+
+         manager.fireEvent(preEvent);
+         if(!preEvent.isVetoed())
+         {
+            if(isExpression(dependency.getVersion()))
+            {
+               for(Properties properties: propertySets)
+               {
+                  if(properties.containsKey(propertyName))
+                  {
+                     properties.put(propertyName, version);
+                  }
+               }
+            }
+            else 
+            {
+               dependency.setVersion(version);
+            }
+            
+            UpdatedDependency event = new UpdatedDependency(project, from, to);
+            manager.fireEvent(event);
+            return true;
+         }
+         else
+         {
+            shell.println("Update attempt vetoed by other Plugin");
+            for(String message : preEvent.getMessages())
+            {
+               shell.println("\t" + message);
+            }
+            return false;
+         }
+      }
+      return false;
+   }
+   
+   private String findNewerVersions(DependencyFacet facet, Dependency dependency)
+   {
+      String currentVersion = dependency.getVersion();
+      if(currentVersion == null || currentVersion.equals(""))
+      {
+          return null; // managed??
+      }
+      else 
+      {
+         org.jboss.forge.project.dependencies.Dependency resolved = facet.resolveProperties(
+               new MavenDependencyAdapter(dependency));
+         
+         org.jboss.forge.project.dependencies.Dependency query = DependencyBuilder.create(resolved)
+               .setVersion("(" + resolved.getVersion() + ",)");
+         
+         List<org.jboss.forge.project.dependencies.Dependency> foundVersions = facet.resolveAvailableVersions(query);
+         if(foundVersions == null || foundVersions.size() == 0)
+         {
+            return null;
+         }
+         else
+         {
+            String gav = dependency.getGroupId() + ":" + dependency.getArtifactId();
+            org.jboss.forge.project.dependencies.Dependency latest = foundVersions.get(foundVersions.size()-1);
+
+            if(resolved.getVersion().equals(latest.getVersion()))
+            {
+               return null;
+            }
+            
+            List<Option> options = Arrays.asList(
+                  new Option(Option.OptionType.YES, "Yes"), 
+                  new Option(Option.OptionType.NO, "No"), 
+                  new Option(Option.OptionType.OTHER, 
+                        MessageFormat.format("Show {0} other versions", 
+                              shell.renderColor(ShellColor.BOLD, String.valueOf(foundVersions.size())))));
+            
+            Option option = shell.promptChoiceTyped(
+                  MessageFormat.format(
+                        "Update {0} from {1} to {2}?", 
+                        gav, resolved.getVersion(), latest.getVersion()),
+                  options, options.get(0));
+            
+            switch(option.getType())
+            {
+               case YES:
+                  return latest.getVersion();
+               case OTHER:
+                  org.jboss.forge.project.dependencies.Dependency choice = shell.promptChoiceTyped(
+                        "Which version would you like to update to?",
+                        foundVersions, latest);
+                  return choice.getVersion();
+               default:
+                  shell.println("Skipping " + gav);
+                  return null;
+            }
+         }
+      }
+   }
+
+   private boolean isExpression(String value)
+   {
+      return value != null && value.startsWith("${");
+   }
+   
+   private String getExpressionName(String value)
+   {
+      return value.replaceAll("\\$\\{(.*)\\}", "$1");
+   }
+   
+   private static class Option
+   {
+      public enum OptionType {
+         YES, NO, OTHER
+      }
+      
+      private String display;
+      private OptionType type;
+      
+      public Option(OptionType type, String display)
+      {
+         this.type = type;
+         this.display = display;
+      }
+      
+      public OptionType getType()
+      {
+         return type;
+      }
+      
+      @Override
+      public String toString()
+      {
+         return this.display;
+      }
+   }
+}

--- a/dev-plugins/src/test/java/org/jboss/forge/dev/mvn/update/UpdateEventObservers.java
+++ b/dev-plugins/src/test/java/org/jboss/forge/dev/mvn/update/UpdateEventObservers.java
@@ -1,0 +1,37 @@
+package org.jboss.forge.dev.mvn.update;
+
+import javax.enterprise.event.Observes;
+
+import org.jboss.forge.project.dependencies.events.UpdatedDependency;
+import org.jboss.forge.project.dependencies.events.UpdatingDependency;
+import org.jboss.forge.shell.Shell;
+import org.jboss.forge.shell.ShellColor;
+
+public class UpdateEventObservers
+{
+   public static String VETO_TEXT = "TEST_VETO_DEPENDENCY";
+   public static String UPDATED_TEXT = "TEST_UPDATED_DEPENDENCY";
+   
+   public static void updating(@Observes UpdatingDependency dep, Shell shell)
+   {
+      if(dep.getTo().getGroupId().startsWith("org.jboss.arquillian.container"))
+      {
+               dep.veto(VETO_TEXT);
+      }
+   }
+
+   public static String red(Shell shell, String output) 
+   {
+      return shell.renderColor(ShellColor.RED, output);
+   }
+   
+   public static void updated(@Observes UpdatedDependency dep, Shell shell)
+   {
+      if(
+            dep.getTo().getGroupId().startsWith("org.jboss.arquillian") && 
+            dep.getTo().getArtifactId().startsWith("arquillian-bom"))
+      {
+         shell.println(UPDATED_TEXT);
+      }
+   }
+}

--- a/dev-plugins/src/test/java/org/jboss/forge/dev/mvn/update/UpdateMavenPomPluginTest.java
+++ b/dev-plugins/src/test/java/org/jboss/forge/dev/mvn/update/UpdateMavenPomPluginTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.dev.mvn.update;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+import org.jboss.forge.shell.Shell;
+import org.jboss.forge.test.AbstractShellTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class UpdateMavenPomPluginTest extends AbstractShellTest
+{
+
+   @Before
+   public void copyFileForIDE() throws Exception {
+
+      copyFile("maven-update/pom.xml");
+      copyFile("maven-update/sub/pom.xml");
+   }
+
+   @SuppressWarnings("resource")
+   private void copyFile(String fileName) throws IOException, FileNotFoundException
+   {
+      File source = new File("src/test/resources/", fileName);
+      File target = new File("target/test-classes/", fileName);
+
+      if(!target.exists())
+      {
+         target.getParentFile().mkdirs();
+         target.createNewFile();
+      }
+
+      FileChannel input = new FileInputStream(source).getChannel();
+      FileChannel output = new FileOutputStream(target).getChannel();
+
+      output.transferFrom(input, 0, input.size());
+
+      input.close();
+      output.close();
+   }
+
+   @Test
+   public void testShouldBeAbleToLsPomFile() throws Exception
+   {
+      Shell shell = getShell();
+      //shell.setAcceptDefaults(true);
+      queueInputLines("", "2", "3", "", "", "", "", "", "");
+      shell.execute("cd target/test-classes/maven-update");
+      shell.execute("maven update");
+
+      String pom = getOutput();
+
+      Assert.assertTrue(
+            "UpdatedDependency event should have been fired",
+            pom.contains(UpdateEventObservers.UPDATED_TEXT));
+      Assert.assertTrue(
+            "UpdateingDependency event should been fired",
+            pom.contains(UpdateEventObservers.VETO_TEXT));
+
+      Assert.assertTrue(
+            "Should allow to skip a given update",
+            pom.contains("Skipping "));
+
+      Assert.assertTrue(
+            "Should show list of available versions",
+            pom.contains("Which version would you like to update to"));
+
+      System.out.println(pom);
+   }
+}

--- a/dev-plugins/src/test/resources/maven-update/pom.xml
+++ b/dev-plugins/src/test/resources/maven-update/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.jboss.forge.test</groupId>
+	<artifactId>maven-update</artifactId>
+	<version>1.0.0</version>
+	<name>Forge - Dev Plugins - Maven Update Test</name>
+	<packaging>pom</packaging>
+
+	<properties>
+		<version.resolver>2.0.0-alpha-6</version.resolver>
+		<version.junit>4.8.1</version.junit>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.jboss.arquillian</groupId>
+				<artifactId>arquillian-bom</artifactId>
+				<version>1.0.0.Final</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.shrinkwrap.resolver</groupId>
+				<artifactId>shrinkwrap-resolver-bom</artifactId>
+				<version>${version.resolver}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<modules>
+		<module>sub</module>
+	</modules>
+</project>

--- a/dev-plugins/src/test/resources/maven-update/sub/pom.xml
+++ b/dev-plugins/src/test/resources/maven-update/sub/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.jboss.forge.test</groupId>
+		<artifactId>maven-update</artifactId>
+		<version>1.0.0</version>
+		<relativePath>../</relativePath>	
+	</parent>
+
+	<artifactId>maven-update-sub</artifactId>
+	<name>Forge - Dev Plugins - Maven Update Sub Test</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jboss.shrinkwrap</groupId>
+			<artifactId>shrinkwrap-api</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.shrinkwrap</groupId>
+			<artifactId>shrinkwrap-impl-base</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${version.junit}</version>
+		</dependency>
+	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>container</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.jboss.arquillian.container</groupId>
+					<artifactId>arquillian-weld-se-embedded-1.1</artifactId>
+					<version>1.0.0.CR4</version>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>a</id>
+			<dependencies>
+				<dependency>
+					<groupId>org.jboss.shrinkwrap</groupId>
+					<artifactId>shrinkwrap-spi</artifactId>
+					<version>1.0.0</version>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>b</id>
+			<properties>
+				<vesion.descriptor>2.0.0-alpha-1</vesion.descriptor>
+			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>org.jboss.shrinkwrap.descriptors</groupId>
+					<artifactId>shrinkwrap-descriptors-bom</artifactId>
+					<version>${vesion.descriptor}</version>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
+</project>

--- a/shell-api/src/main/java/org/jboss/forge/project/dependencies/events/UpdatedDependency.java
+++ b/shell-api/src/main/java/org/jboss/forge/project/dependencies/events/UpdatedDependency.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.project.dependencies.events;
+
+import org.jboss.forge.project.Project;
+import org.jboss.forge.project.dependencies.Dependency;
+
+public final class UpdatedDependency
+{
+   private Dependency from;
+   private Dependency to;
+   
+   private Project project;
+   
+   public UpdatedDependency(Project project, Dependency from, Dependency to)
+   {
+      this.project = project;
+      this.from = from;
+      this.to = to;
+   }
+   
+   public Dependency getFrom()
+   {
+      return from;
+   }
+   
+   public Dependency getTo()
+   {
+      return to;
+   }
+   
+   public Project getProject()
+   {
+      return project;
+   }
+}

--- a/shell-api/src/main/java/org/jboss/forge/project/dependencies/events/UpdatingDependency.java
+++ b/shell-api/src/main/java/org/jboss/forge/project/dependencies/events/UpdatingDependency.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.project.dependencies.events;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.forge.project.Project;
+import org.jboss.forge.project.dependencies.Dependency;
+
+public final class UpdatingDependency
+{
+   private Dependency from;
+   private Dependency to;
+   
+   private Project project;
+   
+   public boolean vetoed = false;
+   public List<String> messages;
+   
+   public UpdatingDependency(Project project, Dependency from, Dependency to)
+   {
+      this.project = project;
+      this.from = from;
+      this.to = to;
+      this.messages = new ArrayList<String>();
+   }
+   
+   public Dependency getFrom()
+   {
+      return from;
+   }
+   
+   public Dependency getTo()
+   {
+      return to;
+   }
+   
+   public Project getProject()
+   {
+      return project;
+   }
+
+   public boolean isVetoed()
+   {
+      return vetoed;
+   }
+   
+   /**
+    * Abort the Update.
+    */
+   public void veto(String message) {
+      vetoed = true;
+      this.messages.add(message);
+   }
+   
+   /**
+    * @return A list of messages from the vetoers
+    */
+   public List<String> getMessages()
+   {
+      return messages;
+   }
+}


### PR DESCRIPTION
The command will run trough current pom and all children to check if there are
newer version of the defined artifacts available in the Maven repositories.

If one is found, the user will be prompted to see if he wants to update,
ignore or see a complete list of available newer versions.

Two events are fired by this Command:
- UpdatedDependency
  
  Fired when the user has choosen to update a given dependency.
  The From and Two Artifact Info is given in the Event. This can be used to
  e.g. provide Release Notes for a given Artifact.
- UpdatingDependency
  
  Fired when the user has choosen to update a given dependency, but before
  the change has been written to disk. The event allow for Observers to
  veto the update. This can be used by other Plugins to warn / abort
  updates that would cause an invalid configuration.

Usage$ maven update
