### PR TITLE
FORGE-814: Supports optional attribute in ManyToOne/OneToOne

### DIFF
--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/FieldPlugin.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/FieldPlugin.java
@@ -273,7 +273,8 @@ public class FieldPlugin implements Plugin
                      type = PromptType.JAVA_VARIABLE_NAME) final String inverseFieldName,
             @Option(name = "fetchType",
                      required = false,
-                     description = "Whether the association should be lazily loaded or must be eagerly fetched.") final FetchType fetchType)
+                     description = "Whether the association should be lazily loaded or must be eagerly fetched.") final FetchType fetchType,
+            @Option(name = "required", required = false, flagOnly = true, description = "Whether the association is required. Sets the optional attribute to false.") final boolean required)
    {
       JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
 
@@ -291,6 +292,7 @@ public class FieldPlugin implements Plugin
          }
 
          Field<JavaClass> localField = addFieldTo(entityClass, fieldEntityClass, fieldName, OneToOne.class);
+         Annotation<JavaClass> annotation = localField.getAnnotation(OneToOne.class);
          if ((inverseFieldName != null) && !inverseFieldName.isEmpty())
          {
             Field<JavaClass> inverseField = addFieldTo(fieldEntityClass, entityClass, inverseFieldName, OneToOne.class);
@@ -300,10 +302,14 @@ public class FieldPlugin implements Plugin
          
          if (fetchType != null)
          {
-            Annotation<JavaClass> annotation = localField.getAnnotation(OneToOne.class);
             annotation.setEnumValue("fetch", fetchType);
-            java.saveJavaSource(entityClass);
          }
+         if (required)
+         {
+            // Set the optional attribute of @OneToOne/@ManyToOne only when false, since the default value is true
+            annotation.setLiteralValue("optional", "false");
+         }
+         java.saveJavaSource(entityClass);
       }
       catch (FileNotFoundException e)
       {
@@ -496,7 +502,8 @@ public class FieldPlugin implements Plugin
                      type = PromptType.JAVA_VARIABLE_NAME) final String inverseFieldName,
             @Option(name = "fetchType",
                      required = false,
-                     description = "Whether the association should be lazily loaded or must be eagerly fetched.") final FetchType fetchType)
+                     description = "Whether the association should be lazily loaded or must be eagerly fetched.") final FetchType fetchType,
+            @Option(name = "required", required = false, flagOnly = true, description = "Whether the association is required. Sets the optional attribute to false.") final boolean required)
    {
       JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
 
@@ -551,6 +558,11 @@ public class FieldPlugin implements Plugin
          if(fetchType != null)
          {
             manyAnnotation.setEnumValue("fetch", fetchType);
+         }
+         if (required)
+         {
+            // Set the optional attribute of @OneToOne/@ManyToOne only when false, since the default value is true
+            manyAnnotation.setLiteralValue("optional", "false");
          }
          java.saveJavaSource(many);
       }

--- a/javaee-impl/src/test/java/org/jboss/forge/spec/jpa/NewFieldPluginTest.java
+++ b/javaee-impl/src/test/java/org/jboss/forge/spec/jpa/NewFieldPluginTest.java
@@ -199,6 +199,7 @@ public class NewFieldPluginTest extends AbstractJPATest
       assertTrue(leftEntity.hasField("right"));
       assertTrue(leftEntity.getField("right").getType().equals(rightEntity.getName()));
       assertTrue(leftEntity.getField("right").hasAnnotation(OneToOne.class));
+      assertNull(leftEntity.getField("right").getAnnotation(OneToOne.class).getAnnotationValue("optional"));
       assertTrue(leftEntity.hasImport(rightEntity.getQualifiedName()));
       assertTrue(leftEntity.hasImport(OneToOne.class));
       assertFalse(leftEntity.hasSyntaxErrors());
@@ -264,8 +265,39 @@ public class NewFieldPluginTest extends AbstractJPATest
       assertTrue(leftEntity.hasField("right"));
       assertTrue(leftEntity.getField("right").getType().equals(rightEntity.getName()));
       assertTrue(leftEntity.getField("right").hasAnnotation(OneToOne.class));
-      assertEquals(leftEntity.getField("right").getAnnotation(OneToOne.class).getEnumValue(FetchType.class, "fetch"),
-               FetchType.EAGER);
+      assertEquals(FetchType.EAGER,
+               leftEntity.getField("right").getAnnotation(OneToOne.class).getEnumValue(FetchType.class, "fetch"));
+      assertTrue(leftEntity.hasImport(rightEntity.getQualifiedName()));
+      assertTrue(leftEntity.hasImport(OneToOne.class));
+      assertFalse(leftEntity.hasSyntaxErrors());
+
+      rightEntity = (JavaClass) project.getFacet(JavaSourceFacet.class).getJavaResource(rightEntity).getJavaSource();
+
+      assertFalse(rightEntity.hasField("left"));
+      assertFalse(rightEntity.hasImport(leftEntity.getQualifiedName()));
+      assertFalse(rightEntity.hasImport(OneToOne.class));
+      assertFalse(rightEntity.hasSyntaxErrors());
+   }
+   
+   @Test
+   public void testNewOneToOneRelationshipNonOptional() throws Exception
+   {
+      Project project = getProject();
+      JavaClass rightEntity = generateEntity(project);
+      JavaClass leftEntity = generateEntity(project);
+
+      getShell().execute(
+               ConstraintInspector.getName(FieldPlugin.class) + " oneToOne --named right --fieldType ~."
+                        + PersistenceFacetImpl.DEFAULT_ENTITY_PACKAGE + "."
+                        + rightEntity.getName() + " --required");
+
+      leftEntity = (JavaClass) project.getFacet(JavaSourceFacet.class).getJavaResource(leftEntity).getJavaSource();
+
+      assertTrue(leftEntity.hasAnnotation(Entity.class));
+      assertTrue(leftEntity.hasField("right"));
+      assertTrue(leftEntity.getField("right").getType().equals(rightEntity.getName()));
+      assertTrue(leftEntity.getField("right").hasAnnotation(OneToOne.class));
+      assertEquals("false", leftEntity.getField("right").getAnnotation(OneToOne.class).getLiteralValue("optional"));
       assertTrue(leftEntity.hasImport(rightEntity.getQualifiedName()));
       assertTrue(leftEntity.hasImport(OneToOne.class));
       assertFalse(leftEntity.hasSyntaxErrors());
@@ -336,8 +368,8 @@ public class NewFieldPluginTest extends AbstractJPATest
                .equals(rightEntity.getQualifiedName()));
       assertTrue(leftEntity.getField("right").hasAnnotation(ManyToMany.class));
       assertNull(leftEntity.getField("right").getAnnotation(ManyToMany.class).getStringValue("mappedBy"));
-      assertEquals(leftEntity.getField("right").getAnnotation(ManyToMany.class).getEnumValue(FetchType.class, "fetch"),
-               FetchType.EAGER);
+      assertEquals(FetchType.EAGER,
+               leftEntity.getField("right").getAnnotation(ManyToMany.class).getEnumValue(FetchType.class, "fetch"));
       assertTrue(leftEntity.hasImport(rightEntity.getQualifiedName()));
       assertTrue(leftEntity.hasImport(ManyToMany.class));
       assertFalse(leftEntity.hasSyntaxErrors());
@@ -408,8 +440,8 @@ public class NewFieldPluginTest extends AbstractJPATest
 
       assertTrue(leftEntity.getField("right").hasAnnotation(OneToMany.class));
       assertNull(leftEntity.getField("right").getAnnotation(OneToMany.class).getStringValue("mappedBy"));
-      assertEquals(leftEntity.getField("right").getAnnotation(OneToMany.class).getEnumValue(FetchType.class, "fetch"),
-               FetchType.EAGER);
+      assertEquals(FetchType.EAGER,
+               leftEntity.getField("right").getAnnotation(OneToMany.class).getEnumValue(FetchType.class, "fetch"));
       assertTrue(leftEntity.hasImport(rightEntity.getQualifiedName()));
       assertTrue(leftEntity.hasImport(OneToMany.class));
       assertFalse(leftEntity.hasSyntaxErrors());
@@ -441,6 +473,7 @@ public class NewFieldPluginTest extends AbstractJPATest
       assertEquals(rightEntity.getName(), leftEntity.getField("right").getType());
       assertTrue(leftEntity.getField("right").hasAnnotation(ManyToOne.class));
       assertNull(leftEntity.getField("right").getAnnotation(ManyToOne.class).getStringValue("mappedBy"));
+      assertNull(leftEntity.getField("right").getAnnotation(ManyToOne.class).getStringValue("optional"));
       assertTrue(leftEntity.hasImport(rightEntity.getQualifiedName()));
       assertTrue(leftEntity.hasImport(ManyToOne.class));
       assertFalse(leftEntity.hasSyntaxErrors());
@@ -472,8 +505,40 @@ public class NewFieldPluginTest extends AbstractJPATest
       assertEquals(rightEntity.getName(), leftEntity.getField("right").getType());
       assertTrue(leftEntity.getField("right").hasAnnotation(ManyToOne.class));
       assertNull(leftEntity.getField("right").getAnnotation(ManyToOne.class).getStringValue("mappedBy"));
-      assertEquals(leftEntity.getField("right").getAnnotation(ManyToOne.class).getEnumValue(FetchType.class, "fetch"),
-               FetchType.EAGER);
+      assertEquals(FetchType.EAGER,
+               leftEntity.getField("right").getAnnotation(ManyToOne.class).getEnumValue(FetchType.class, "fetch"));
+      assertTrue(leftEntity.hasImport(rightEntity.getQualifiedName()));
+      assertTrue(leftEntity.hasImport(ManyToOne.class));
+      assertFalse(leftEntity.hasSyntaxErrors());
+
+      rightEntity = (JavaClass) project.getFacet(JavaSourceFacet.class).getJavaResource(rightEntity).getJavaSource();
+
+      assertFalse(rightEntity.hasField("left"));
+      assertFalse(rightEntity.hasImport(leftEntity.getQualifiedName()));
+      assertFalse(rightEntity.hasImport(OneToMany.class));
+      assertFalse(rightEntity.hasSyntaxErrors());
+   }
+   
+   @Test
+   public void testNewManyToOneRelationshipNonOptional() throws Exception
+   {
+      Project project = getProject();
+      JavaClass rightEntity = generateEntity(project);
+      JavaClass leftEntity = generateEntity(project);
+
+      getShell().execute(
+               ConstraintInspector.getName(FieldPlugin.class) + " manyToOne --named right --fieldType ~."
+                        + PersistenceFacetImpl.DEFAULT_ENTITY_PACKAGE + "."
+                        + rightEntity.getName() + " --required");
+
+      leftEntity = (JavaClass) project.getFacet(JavaSourceFacet.class).getJavaResource(leftEntity).getJavaSource();
+
+      assertTrue(leftEntity.hasAnnotation(Entity.class));
+      assertTrue(leftEntity.hasField("right"));
+      assertEquals(rightEntity.getName(), leftEntity.getField("right").getType());
+      assertTrue(leftEntity.getField("right").hasAnnotation(ManyToOne.class));
+      assertNull(leftEntity.getField("right").getAnnotation(ManyToOne.class).getStringValue("mappedBy"));
+      assertEquals("false", leftEntity.getField("right").getAnnotation(ManyToOne.class).getLiteralValue("optional"));
       assertTrue(leftEntity.hasImport(rightEntity.getQualifiedName()));
       assertTrue(leftEntity.hasImport(ManyToOne.class));
       assertFalse(leftEntity.hasSyntaxErrors());


### PR DESCRIPTION
Allows for optional attribute values to be specified for `@ManyToOne` and `@OneToOne` annotations. When not specified in the field command, this attribute is omitted, to avoid annotation 'noise'.
