### PR TITLE
[FORGE-831] Use check for a log manager service

### DIFF
--- a/container/pom.xml
+++ b/container/pom.xml
@@ -1,10 +1,10 @@
-<!-- ~ JBoss, by Red Hat. ~ Copyright 2010, Red Hat, Inc., and individual contributors ~ by the @authors tag. See the copyright.txt 
-   in the distribution for a ~ full listing of individual contributors. ~ ~ This is free software; you can redistribute it and/or 
-   modify it ~ under the terms of the GNU Lesser General Public License as ~ published by the Free Software Foundation; either 
-   version 2.1 of ~ the License, or (at your option) any later version. ~ ~ This software is distributed in the hope that it 
-   will be useful, ~ but WITHOUT ANY WARRANTY; without even the implied warranty of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR 
-   PURPOSE. See the GNU ~ Lesser General Public License for more details. ~ ~ You should have received a copy of the GNU Lesser 
-   General Public ~ License along with this software; if not, write to the Free ~ Software Foundation, Inc., 51 Franklin St, 
+<!-- ~ JBoss, by Red Hat. ~ Copyright 2010, Red Hat, Inc., and individual contributors ~ by the @authors tag. See the copyright.txt
+   in the distribution for a ~ full listing of individual contributors. ~ ~ This is free software; you can redistribute it and/or
+   modify it ~ under the terms of the GNU Lesser General Public License as ~ published by the Free Software Foundation; either
+   version 2.1 of ~ the License, or (at your option) any later version. ~ ~ This software is distributed in the hope that it
+   will be useful, ~ but WITHOUT ANY WARRANTY; without even the implied warranty of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR
+   PURPOSE. See the GNU ~ Lesser General Public License for more details. ~ ~ You should have received a copy of the GNU Lesser
+   General Public ~ License along with this software; if not, write to the Free ~ Software Foundation, Inc., 51 Franklin St,
    Fifth Floor, Boston, MA ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -43,6 +43,11 @@
       <dependency>
          <groupId>org.jboss.forge</groupId>
          <artifactId>forge-proxy</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.logmanager</groupId>
+         <artifactId>jboss-logmanager</artifactId>
       </dependency>
 
       <dependency>

--- a/container/src/main/java/org/jboss/forge/container/modules/providers/BaseModuleSpecProvider.java
+++ b/container/src/main/java/org/jboss/forge/container/modules/providers/BaseModuleSpecProvider.java
@@ -567,6 +567,12 @@ public abstract class BaseModuleSpecProvider implements ModuleSpecProvider
       systemPaths.add("org/jboss/forge/parser/xml/util");
       systemPaths.add("org/jboss/forge/proxy");
       systemPaths.add("org/jboss/forge/test");
+      systemPaths.add("org/jboss/logmanager");
+      systemPaths.add("org/jboss/logmanager/config");
+      systemPaths.add("org/jboss/logmanager/errormanager");
+      systemPaths.add("org/jboss/logmanager/filters");
+      systemPaths.add("org/jboss/logmanager/formatters");
+      systemPaths.add("org/jboss/logmanager/handlers");
       systemPaths.add("org/jboss/modules");
       systemPaths.add("org/jboss/modules/filter");
       systemPaths.add("org/jboss/modules/log");

--- a/dist/src/main/resources/bin/forge
+++ b/dist/src/main/resources/bin/forge
@@ -165,6 +165,9 @@ if $cygwin; then
     HOME=`cygpath --path --windows "$HOME"`
 fi
 
-forge_exec_cmd="\"$JAVACMD\" $FORGE_DEBUG_ARGS $FORGE_OPTS \"-Dforge.home=${FORGE_HOME}\" -cp \"${FORGE_HOME}/lib/*\" $FORGE_MAIN_CLASS"
+forge_exec_cmd="\"$JAVACMD\" $FORGE_DEBUG_ARGS $FORGE_OPTS \"-Dforge.home=${FORGE_HOME}\" \
+   \"-Dorg.jboss.forge.log.file=${FORGE_HOME}/log/forge.log\" \
+   \"-Dlogging.configuration=file:${FORGE_HOME}/logging.properties\" \
+   -cp \"${FORGE_HOME}/lib/*\" $FORGE_MAIN_CLASS"
 
 eval $forge_exec_cmd "$QUOTED_ARGS"

--- a/dist/src/main/resources/bin/forge.bat
+++ b/dist/src/main/resources/bin/forge.bat
@@ -136,7 +136,10 @@ goto runForge
 @REM Start Forge
 :runForge
 set FORGE_MAIN_CLASS=org.jboss.forge.bootstrap.Bootstrap
-%FORGE_JAVA_EXE% %FORGE_DEBUG_ARGS% %FORGE_OPTS% "-Dforge.home=%FORGE_HOME%" -cp "%FORGE_HOME%\lib\*" %FORGE_MAIN_CLASS%
+%FORGE_JAVA_EXE% %FORGE_DEBUG_ARGS% %FORGE_OPTS% "-Dforge.home=%FORGE_HOME%" ^
+   "-Dorg.jboss.forge.log.file=%FORGE_HOME%\log\forge.log" ^
+   "-Dlogging.configuration=file:%FORGE_HOME%\logging.properties" ^
+   -cp "%FORGE_HOME%\lib\*" %FORGE_MAIN_CLASS%
 if ERRORLEVEL 1 goto error
 goto end
 

--- a/dist/src/main/resources/logging.properties
+++ b/dist/src/main/resources/logging.properties
@@ -1,0 +1,58 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2013, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+# Additional loggers to configure (the root logger is always configured)
+loggers=
+
+logger.level=INFO
+# Add CONSOLE to the comma delimited list if console output is wanted
+logger.handlers=FILE
+
+# Console handler
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.level=INFO
+handler.CONSOLE.formatter=CONSOLE
+handler.CONSOLE.properties=autoFlush,target
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.target=SYSTEM_OUT
+
+# Rotating handler
+handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
+handler.FILE.level=ALL
+handler.FILE.formatter=PATTERN
+handler.FILE.properties=autoFlush,append,fileName,suffix
+handler.FILE.constructorProperties=fileName,append
+handler.FILE.autoFlush=true
+handler.FILE.append=true
+handler.FILE.fileName=${org.jboss.forge.log.file:forge.log}
+handler.FILE.suffix=.yyyy-MM-dd
+
+# Format for the console. The %K{level} is for colorized output
+formatter.CONSOLE=org.jboss.logmanager.formatters.PatternFormatter
+formatter.CONSOLE.properties=pattern
+formatter.CONSOLE.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+
+# Default pattern formatter
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.constructorProperties=pattern
+formatter.PATTERN.pattern=%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
       <version.arquillian>1.0.3.Final</version.arquillian>
       <version.arquillian.container>1.0.0.CR5</version.arquillian.container>
       <version.cdi>1.1-20130305</version.cdi>
+      <version.org.jboss.logmanager.jboss-logmanager>1.4.1.Final</version.org.jboss.logmanager.jboss-logmanager>
       <version.jboss.spec>3.0.1.Final</version.jboss.spec>
       <version.jboss.modules>1.1.3.GA</version.jboss.modules>
       <version.junit>4.11</version.junit>
@@ -137,6 +138,13 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-ext</artifactId>
             <version>${version.slf4j}</version>
+         </dependency>
+
+         <!-- JBoss Logging dependencies -->
+         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <version>${version.org.jboss.logmanager.jboss-logmanager}</version>
          </dependency>
 
          <dependency>


### PR DESCRIPTION
JBoss Log Manager has a service loader file to indicate it should be the log manager. This PR looks for the file and sets the `java.util.logging.manager` system property in the bootstrap.

Also added a default configuration, `logging.properites`, to log output to the `$FORGE_HOME/log/forge.log` file.
