### PR TITLE
FORGE-572 Fixed bug involving annotations on properties

### DIFF
--- a/scaffold-faces/src/main/java/org/jboss/forge/scaffold/faces/FacesScaffold.java
+++ b/scaffold-faces/src/main/java/org/jboss/forge/scaffold/faces/FacesScaffold.java
@@ -863,7 +863,7 @@ public class FacesScaffold extends BaseFacet implements ScaffoldProvider
                Field<?> field = (Field<?>) m;
                pkName = field.getName();
                pkType = field.getType();
-               nullablePkType = field.getType();
+               nullablePkType = pkType;
                break;
             }
 
@@ -877,6 +877,7 @@ public class FacesScaffold extends BaseFacet implements ScaffoldProvider
             {
                pkType = method.getParameters().get(0).getType();
             }
+            nullablePkType = pkType;
             break;
          }
       }


### PR DESCRIPTION
@Id annotation on fields was parsed correctly to obtain primary key metadata. The fix ensures the same even for @Id annotations on properties of JPA entities.
