### PR TITLE
[FORGE-881] Change the thrown exception to the correct type as indicated by the interface

### DIFF
--- a/shell/src/main/java/org/jboss/forge/shell/env/ScopedConfigurationAdapter.java
+++ b/shell/src/main/java/org/jboss/forge/shell/env/ScopedConfigurationAdapter.java
@@ -24,7 +24,7 @@ import org.jboss.forge.env.ConfigurationScope;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
- * 
+ *
  */
 @Typed()
 public class ScopedConfigurationAdapter implements Configuration
@@ -58,7 +58,7 @@ public class ScopedConfigurationAdapter implements Configuration
       Configuration configuration = delegates.get(scope);
       if (configuration == null)
       {
-         throw new IllegalStateException("No delegates were found in configuration - cannot retrieve scope");
+         throw new IllegalArgumentException("No delegates were found in configuration - cannot retrieve scope");
       }
       return configuration;
    }


### PR DESCRIPTION
The API indicated an `IllegalArgumentException` should be thrown, but the implementation was throwing `IllegalStateException`. This just replaces the thrown type with the correct type.
