### PR TITLE
FORGE-863: Maven mirror settings not used within forge: patch2

### DIFF
--- a/project-model-maven/src/main/java/org/jboss/forge/maven/dependencies/RepositoryLookup.java
+++ b/project-model-maven/src/main/java/org/jboss/forge/maven/dependencies/RepositoryLookup.java
@@ -18,17 +18,17 @@ import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Settings;
 import org.jboss.forge.ForgeEnvironment;
+import org.jboss.forge.maven.MavenCoreFacet;
 import org.jboss.forge.maven.RepositoryUtils;
 import org.jboss.forge.maven.facets.MavenContainer;
 import org.jboss.forge.parser.java.util.Strings;
+import org.jboss.forge.project.Project;
 import org.jboss.forge.project.ProjectModelException;
 import org.jboss.forge.project.dependencies.Dependency;
 import org.jboss.forge.project.dependencies.DependencyBuilder;
 import org.jboss.forge.project.dependencies.DependencyMetadata;
 import org.jboss.forge.project.dependencies.DependencyRepository;
-import org.jboss.forge.project.dependencies.DependencyRepositoryImpl;
 import org.jboss.forge.project.dependencies.DependencyResolverProvider;
-import org.jboss.forge.project.facets.DependencyFacet.KnownRepository;
 import org.jboss.forge.project.services.ResourceFactory;
 import org.jboss.forge.resources.DependencyResource;
 import org.jboss.forge.resources.DirectoryResource;
@@ -64,6 +64,7 @@ public class RepositoryLookup implements DependencyResolverProvider
    private MavenContainer container;
    private ResourceFactory factory;
    private ForgeEnvironment environment;
+   private Project project;
 
    public RepositoryLookup()
    {
@@ -71,11 +72,12 @@ public class RepositoryLookup implements DependencyResolverProvider
 
    @Inject
    public RepositoryLookup(final MavenContainer container, final ResourceFactory factory,
-            final ForgeEnvironment environment)
+            final ForgeEnvironment environment, final Project project)
    {
       this.container = container;
       this.factory = factory;
       this.environment = environment;
+      this.project = project;
    }
 
    @Override
@@ -342,24 +344,21 @@ public class RepositoryLookup implements DependencyResolverProvider
    private List<RemoteRepository> convertToMavenRepos(final List<DependencyRepository> repositories)
    {
       List<DependencyRepository> temp = new ArrayList<DependencyRepository>();
-      temp.addAll(repositories);
-
       List<RemoteRepository> remoteRepos = new ArrayList<RemoteRepository>();
-      boolean hasCentral = false;
-      for (DependencyRepository deprep : temp)
+
+      if (repositories == null || repositories.size() == 0)
       {
-         remoteRepos.add(convertToMavenRepo(deprep));
-         if (KnownRepository.CENTRAL.getUrl().equals(deprep.getUrl()))
-         {
-            hasCentral = true;
-         }
+         MavenCoreFacet maven = project.getFacet(MavenCoreFacet.class);
+         remoteRepos.addAll(maven.getMavenProject().getRemoteProjectRepositories());
       }
-      if (!hasCentral)
+      else
       {
-         RemoteRepository central = convertToMavenRepo(new DependencyRepositoryImpl(KnownRepository.CENTRAL.getId(),
-                  KnownRepository.CENTRAL.getUrl()));
-         central.setPolicy(true, new RepositoryPolicy().setEnabled(false));
-         remoteRepos.add(central);
+         temp.addAll(repositories);
+
+         for (DependencyRepository deprep : temp)
+         {
+            remoteRepos.add(convertToMavenRepo(deprep));
+         }
       }
       return remoteRepos;
    }

--- a/project-model-maven/src/main/java/org/jboss/forge/maven/facets/MavenDependencyFacet.java
+++ b/project-model-maven/src/main/java/org/jboss/forge/maven/facets/MavenDependencyFacet.java
@@ -40,6 +40,7 @@ import org.jboss.forge.project.facets.DependencyFacet;
 import org.jboss.forge.project.facets.FacetNotFoundException;
 import org.jboss.forge.shell.plugins.Alias;
 import org.jboss.forge.shell.plugins.RequiresFacet;
+import org.sonatype.aether.repository.RemoteRepository;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
@@ -463,11 +464,10 @@ public class MavenDependencyFacet extends BaseFacet implements DependencyFacet, 
    {
       List<DependencyRepository> results = new ArrayList<DependencyRepository>();
       MavenCoreFacet maven = project.getFacet(MavenCoreFacet.class);
-      Model pom = maven.getPOM();
-      List<Repository> repos = pom.getRepositories();
-      for (Repository repo : repos)
+      List<RemoteRepository> remoteProjectRepositories = maven.getMavenProject().getRemoteProjectRepositories();
+      for (RemoteRepository remoteRepository : remoteProjectRepositories)
       {
-         results.add(new DependencyRepositoryImpl(repo.getId(), repo.getUrl()));
+         results.add(new DependencyRepositoryImpl(remoteRepository.getId(), remoteRepository.getUrl()));
       }
       return Collections.unmodifiableList(results);
    }


### PR DESCRIPTION
to solve issue described in https://github.com/forge/core/commit/364cbd0b4045b64dea1ba3c640866012798e310e
