### PR TITLE
Added CascadeType support in field plugin

### DIFF
--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/CascadeTypeCompleter.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/CascadeTypeCompleter.java
@@ -1,0 +1,18 @@
+package org.jboss.forge.spec.javaee.jpa;
+
+import java.util.Arrays;
+
+import javax.persistence.CascadeType;
+
+import org.jboss.forge.shell.completer.SimpleTokenCompleter;
+
+public class CascadeTypeCompleter extends SimpleTokenCompleter
+{
+
+   @Override
+   public Iterable<?> getCompletionTokens()
+   {
+      return Arrays.asList(CascadeType.values());
+   }
+
+}

--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/FieldPlugin.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/FieldPlugin.java
@@ -302,7 +302,11 @@ public class FieldPlugin implements Plugin
             @Option(name = "fetchType",
                      required = false,
                      description = "Whether the association should be lazily loaded or must be eagerly fetched.") final FetchType fetchType,
-            @Option(name = "required", required = false, flagOnly = true, description = "Whether the association is required. Sets the optional attribute to false.") final boolean required)
+            @Option(name = "required", required = false, flagOnly = true, description = "Whether the association is required. Sets the optional attribute to false.") final boolean required,
+            @Option(name = "cascade",
+                     required = false,
+                     completer = CascadeTypeCompleter.class,
+                     description = "Define the set of operations that are cascaded to the target.") final CascadeType[] cascadeTypes)
    {
       JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
 
@@ -337,6 +341,10 @@ public class FieldPlugin implements Plugin
             // Set the optional attribute of @OneToOne/@ManyToOne only when false, since the default value is true
             annotation.setLiteralValue("optional", "false");
          }
+         if(cascadeTypes !=null && cascadeTypes.length > 0)
+         {
+            annotation.setEnumArrayValue("cascade", cascadeTypes);
+         }
          java.saveJavaSource(entityClass);
       }
       catch (FileNotFoundException e)
@@ -361,7 +369,10 @@ public class FieldPlugin implements Plugin
                      type = PromptType.JAVA_VARIABLE_NAME) final String inverseFieldName,
             @Option(name = "fetchType",
                      required = false,
-                     description = "Whether the association should be lazily loaded or must be eagerly fetched.") final FetchType fetchType)
+                     description = "Whether the association should be lazily loaded or must be eagerly fetched.") final FetchType fetchType,
+            @Option(name = "cascade",
+                     required = false,
+                     description = "Define the set of operations that are cascaded to the target.") final CascadeType[] cascadeTypes)
    {
 
       JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
@@ -423,6 +434,10 @@ public class FieldPlugin implements Plugin
          {
             annotation.setEnumValue("fetch", fetchType);
          }
+         if(cascadeTypes !=null && cascadeTypes.length > 0)
+         {
+            annotation.setEnumArrayValue("cascade", cascadeTypes);
+         }
          java.saveJavaSource(entity);
       }
       catch (FileNotFoundException e)
@@ -448,7 +463,10 @@ public class FieldPlugin implements Plugin
                      type = PromptType.JAVA_VARIABLE_NAME) final String inverseFieldName,
             @Option(name = "fetchType",
                      required = false,
-                     description = "Whether the association should be lazily loaded or must be eagerly fetched.") final FetchType fetchType)
+                     description = "Whether the association should be lazily loaded or must be eagerly fetched.") final FetchType fetchType,
+            @Option(name = "cascade",
+                     required = false,
+                     description = "Define the set of operations that are cascaded to the target.") final CascadeType[] cascadeTypes)
    {
       JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
 
@@ -506,6 +524,10 @@ public class FieldPlugin implements Plugin
          {
             annotation.setEnumValue("fetch", fetchType);
          }
+         if(cascadeTypes !=null && cascadeTypes.length > 0)
+         {
+            annotation.setEnumArrayValue("cascade", cascadeTypes);
+         }
          java.saveJavaSource(one);
       }
       catch (FileNotFoundException e)
@@ -531,7 +553,10 @@ public class FieldPlugin implements Plugin
             @Option(name = "fetchType",
                      required = false,
                      description = "Whether the association should be lazily loaded or must be eagerly fetched.") final FetchType fetchType,
-            @Option(name = "required", required = false, flagOnly = true, description = "Whether the association is required. Sets the optional attribute to false.") final boolean required)
+            @Option(name = "required", required = false, flagOnly = true, description = "Whether the association is required. Sets the optional attribute to false.") final boolean required,
+            @Option(name = "cascade",
+                     required = false,
+                     description = "Define the set of operations that are cascaded to the target.") final CascadeType[] cascadeTypes)
    {
       JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
 
@@ -591,6 +616,10 @@ public class FieldPlugin implements Plugin
          {
             // Set the optional attribute of @OneToOne/@ManyToOne only when false, since the default value is true
             manyAnnotation.setLiteralValue("optional", "false");
+         }
+         if(cascadeTypes !=null && cascadeTypes.length > 0)
+         {
+            manyAnnotation.setEnumArrayValue("cascade", cascadeTypes);
          }
          java.saveJavaSource(many);
       }

--- a/shell/src/main/java/org/jboss/forge/shell/command/Execution.java
+++ b/shell/src/main/java/org/jboss/forge/shell/command/Execution.java
@@ -7,6 +7,7 @@
 package org.jboss.forge.shell.command;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.Set;
 
@@ -90,6 +91,19 @@ public class Execution
                if (parmTypes[i].isEnum())
                {
                   paramStaging[i] = Enums.valueOf(parmTypes[i], parameterArray[i]);
+               }
+               else if(parmTypes[i].isArray() && parmTypes[i].getComponentType().isEnum())
+               {
+                  Object[] array = (Object[]) parameterArray[i];
+                  if (array != null)
+                  {
+                     Object enums = Array.newInstance(parmTypes[i].getComponentType(), array.length);
+                     for (int ctr = 0; ctr < array.length; ctr++)
+                     {
+                        Array.set(enums, ctr, Enums.valueOf(parmTypes[i].getComponentType(), array[ctr]));
+                     }
+                     paramStaging[i] = enums;
+                  }
                }
                else
                {


### PR DESCRIPTION
Also added support for parsing Enum arrays into the Forge shell. This is done to prevent MVEL2 from throwing an NPE.

Note that there are some problems with TAB completion for Array-typed arguments for options, despite the incoming change.
