### PR TITLE
FORGE-917 Fixes to ensure that immutable classes are not scaffolded.

### DIFF
--- a/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/FacesScaffoldTest.java
+++ b/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/FacesScaffoldTest.java
@@ -22,6 +22,7 @@ import org.jboss.forge.resources.FileResource;
 import org.jboss.forge.resources.java.JavaResource;
 import org.jboss.forge.scaffold.faces.metawidget.widgetbuilder.EntityWidgetBuilder;
 import org.jboss.forge.scaffold.faces.metawidget.widgetbuilder.EntityWidgetBuilderConfig;
+import org.jboss.forge.scaffold.util.ScaffoldUtil;
 import org.jboss.forge.shell.exceptions.PluginExecutionException;
 import org.jboss.forge.shell.util.Streams;
 import org.jboss.forge.spec.javaee.ServletFacet;
@@ -115,6 +116,28 @@ public class FacesScaffoldTest extends AbstractFacesScaffoldTest
 
       queueInputLines("", "");
       getShell().execute("scaffold from-entity");
+   }
+   
+   @Test()
+   public void testCannotGenerateFromImmutableEntity() throws Exception
+   {
+      Project project = setupScaffoldProject();
+      
+      JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
+      ScaffoldUtil
+               .createOrOverwrite(
+                        null,
+                        java.getJavaResource("org/jboss/forge/scaffold/faces/ImmutableClass.java"),
+                        getClass()
+                                 .getResourceAsStream(
+                                          "/org/jboss/forge/scaffold/faces/ImmutableClass.java"),
+                        true);
+
+      queueInputLines("", "");
+      getShell().execute("scaffold from-entity org.jboss.forge.scaffold.faces.ImmutableClass");
+      
+      String commandOutput = getOutput();
+      Assert.assertTrue(commandOutput.contains("Skipped non-@Entity Java resource [org.jboss.forge.scaffold.faces.ImmutableClass]"));
    }
 
    @Test
@@ -1104,7 +1127,7 @@ public class FacesScaffoldTest extends AbstractFacesScaffoldTest
 
       CompositeWidgetBuilder<StaticXmlWidget, StaticXmlMetawidget> newWidgetBuilder = new FacesScaffold(null, null,
                null,
-               null).insertRichFacesWidgetBuilder(existingWidgetBuilder);
+               null, null).insertRichFacesWidgetBuilder(existingWidgetBuilder);
 
       assertTrue(newWidgetBuilder.getWidgetBuilders()[0] instanceof EntityWidgetBuilder);
       assertTrue(newWidgetBuilder.getWidgetBuilders()[1] instanceof ReadOnlyWidgetBuilder);
@@ -1115,7 +1138,7 @@ public class FacesScaffoldTest extends AbstractFacesScaffoldTest
                new CompositeWidgetBuilderConfig<StaticXmlWidget, StaticXmlMetawidget>().setWidgetBuilders(
                         new ReadOnlyWidgetBuilder(), new HtmlWidgetBuilder()));
 
-      newWidgetBuilder = new FacesScaffold(null, null, null, null).insertRichFacesWidgetBuilder(existingWidgetBuilder);
+      newWidgetBuilder = new FacesScaffold(null, null, null, null, null).insertRichFacesWidgetBuilder(existingWidgetBuilder);
 
       assertTrue(newWidgetBuilder.getWidgetBuilders()[0] instanceof ReadOnlyWidgetBuilder);
       assertTrue(newWidgetBuilder.getWidgetBuilders()[1] instanceof RichFacesWidgetBuilder);
@@ -1127,7 +1150,7 @@ public class FacesScaffoldTest extends AbstractFacesScaffoldTest
                new CompositeWidgetBuilderConfig<StaticXmlWidget, StaticXmlMetawidget>().setWidgetBuilders(
                         new EntityWidgetBuilder(new EntityWidgetBuilderConfig()), new ReadOnlyWidgetBuilder()));
 
-      newWidgetBuilder = new FacesScaffold(null, null, null, null).insertRichFacesWidgetBuilder(existingWidgetBuilder);
+      newWidgetBuilder = new FacesScaffold(null, null, null, null, null).insertRichFacesWidgetBuilder(existingWidgetBuilder);
 
       assertTrue(newWidgetBuilder.getWidgetBuilders()[0] instanceof EntityWidgetBuilder);
       assertTrue(newWidgetBuilder.getWidgetBuilders()[1] instanceof ReadOnlyWidgetBuilder);
@@ -1139,7 +1162,7 @@ public class FacesScaffoldTest extends AbstractFacesScaffoldTest
                new CompositeWidgetBuilderConfig<StaticXmlWidget, StaticXmlMetawidget>().setWidgetBuilders(
                         new EntityWidgetBuilder(new EntityWidgetBuilderConfig()), new HtmlWidgetBuilder()));
 
-      newWidgetBuilder = new FacesScaffold(null, null, null, null).insertRichFacesWidgetBuilder(existingWidgetBuilder);
+      newWidgetBuilder = new FacesScaffold(null, null, null, null, null).insertRichFacesWidgetBuilder(existingWidgetBuilder);
 
       assertTrue(newWidgetBuilder.getWidgetBuilders()[0] instanceof RichFacesWidgetBuilder);
       assertTrue(newWidgetBuilder.getWidgetBuilders()[1] instanceof EntityWidgetBuilder);
@@ -1152,7 +1175,7 @@ public class FacesScaffoldTest extends AbstractFacesScaffoldTest
                         new EntityWidgetBuilder(new EntityWidgetBuilderConfig()), new RichFacesWidgetBuilder(),
                         new HtmlWidgetBuilder()));
 
-      newWidgetBuilder = new FacesScaffold(null, null, null, null).insertRichFacesWidgetBuilder(existingWidgetBuilder);
+      newWidgetBuilder = new FacesScaffold(null, null, null, null, null).insertRichFacesWidgetBuilder(existingWidgetBuilder);
 
       assertTrue(newWidgetBuilder.getWidgetBuilders()[0] instanceof EntityWidgetBuilder);
       assertTrue(newWidgetBuilder.getWidgetBuilders()[1] instanceof RichFacesWidgetBuilder);

--- a/scaffold-faces/src/test/resources/org/jboss/forge/scaffold/faces/ImmutableClass.java
+++ b/scaffold-faces/src/test/resources/org/jboss/forge/scaffold/faces/ImmutableClass.java
@@ -1,0 +1,20 @@
+package org.jboss.forge.scaffold.faces;
+
+/**
+ * Used to test scaffold generation of an immutable class - no setters only getters
+ */
+
+public class ImmutableClass
+{
+   //
+   // Field with Getter
+   //
+   
+   private String normalField;
+   
+   public String getNormalField()
+   {
+      return this.normalField;
+   }
+
+}

--- a/scaffold-plugins/src/main/java/org/jboss/forge/scaffold/plugins/ScaffoldPlugin.java
+++ b/scaffold-plugins/src/main/java/org/jboss/forge/scaffold/plugins/ScaffoldPlugin.java
@@ -175,9 +175,9 @@ public class ScaffoldPlugin implements Plugin
          if (!generatedResources.isEmpty())
          {
             generatedEvent.fire(new ScaffoldGeneratedResources(provider, prepareResources(generatedResources)));
+            ShellMessages.success(writer, "Generated UI for [" + entity.getQualifiedName() + "]");
          }
 
-         ShellMessages.success(writer, "Generated UI for [" + entity.getQualifiedName() + "]");
       }
 
    }


### PR DESCRIPTION
These changes are introduced outside MetaWidget since the context is not available to determine whether the inspected class is being scaffolded or not. Hence, the decision to avoid scaffolding the class is taken well before inspection.

I've taken the decision to omit scaffolding such classes even through they may appear in the search results, since they cannot be searched for, and neither can they be created or updated without using their non-0-arg constructors. Using them otherwise leads to PropertyNotWritableExceptions being thrown due to non-existent setters. Changing the class to add setters is out of question since that would change their immutable property.
