### PR TITLE
FORGE-913 Added support for allowing timestamp input via Richfaces calendar

### DIFF
--- a/scaffold-faces/src/main/java/org/jboss/forge/scaffold/faces/metawidget/inspectionresultprocessor/RichfacesCalendarInspectionResultProcessor.java
+++ b/scaffold-faces/src/main/java/org/jboss/forge/scaffold/faces/metawidget/inspectionresultprocessor/RichfacesCalendarInspectionResultProcessor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.scaffold.faces.metawidget.inspectionresultprocessor;
+
+import static org.metawidget.inspector.InspectionResultConstants.DATETIME_PATTERN;
+import static org.metawidget.inspector.InspectionResultConstants.DATETIME_TYPE;
+import java.util.Map;
+
+import org.metawidget.inspectionresultprocessor.impl.BaseInspectionResultProcessor;
+
+/**
+ * Processes the inspection result to add additional semantic information for the MetaWidget Richfaces widgetbuilder.
+ * See FORGE-913.
+ * 
+ * @author Vineet Reynolds
+ */
+
+public class RichfacesCalendarInspectionResultProcessor<M> extends BaseInspectionResultProcessor<M>
+{
+   //
+   // Protected methods
+   //
+
+   @Override
+   protected void processAttributes(Map<String, String> attributes, M metawidget)
+   {
+      String dateTimeType = attributes.get(DATETIME_TYPE);
+      if(dateTimeType != null && dateTimeType.equals("both"))
+      {
+         attributes.put(DATETIME_PATTERN, "MMM d, yyyy hh:mm:ss a");
+      }
+   }
+}

--- a/scaffold-faces/src/main/resources/scaffold/faces/metawidget-entity.xml
+++ b/scaffold-faces/src/main/resources/scaffold/faces/metawidget-entity.xml
@@ -48,6 +48,7 @@
                 <inspectionResultProcessors>
                     <array>
                         <generatedValueInspectionResultProcessor xmlns="java:org.jboss.forge.scaffold.faces.metawidget.inspectionresultprocessor"/>
+                        <richfacesCalendarInspectionResultProcessor xmlns="java:org.jboss.forge.scaffold.faces.metawidget.inspectionresultprocessor"/>
                     </array>
                 </inspectionResultProcessors>
                 


### PR DESCRIPTION
This adds support for supplying timestamps via the generated scaffold, with a minor disadvantage - the time is defaulted to 12:00PM, but can be modified again. Fixing this requires adding support in Metawidget to display the 'apply' button.

Additionally, this still does not support the input of time fields, since Richfaces calendar does not support this component yet.
