### PR TITLE
FORGE-916 Implementation of support for bidirectional deletes

### DIFF
--- a/scaffold-faces/src/main/java/org/jboss/forge/scaffold/faces/metawidget/inspector/ForgeInspectionResultConstants.java
+++ b/scaffold-faces/src/main/java/org/jboss/forge/scaffold/faces/metawidget/inspector/ForgeInspectionResultConstants.java
@@ -21,6 +21,16 @@ public final class ForgeInspectionResultConstants
    public static final String N_TO_MANY = "n-to-many";
 
    public static final String ONE_TO_ONE = "one-to-one";
+   
+   public static final String JPA_ONE_TO_ONE = "one-to-one";
+   
+   public static final String JPA_MANY_TO_ONE = "many-to-one";
+   
+   public static final String JPA_ONE_TO_MANY = "one-to-many";
+   
+   public static final String JPA_MANY_TO_MANY = "many-to-many";
+   
+   public static final String JPA_REL_TYPE = "jpa-relation-type";
 
    /**
     * Whether the field is an Id.
@@ -38,6 +48,16 @@ public final class ForgeInspectionResultConstants
     * Whether the field represents a generated value
     */
    public static final String GENERATED_VALUE = "generated-value";
+   
+   /**
+    * The owning field of a bi-directional relationship
+    */
+   public static final String OWNING_FIELD = "owning-field";
+   
+   /**
+    * The inverse field of a bi-directional relationship
+    */
+   public static final String INVERSE_FIELD = "inverse-field";
 
    //
    // Private constructor

--- a/scaffold-faces/src/main/java/org/jboss/forge/scaffold/faces/metawidget/widgetbuilder/RemoveEntityWidgetBuilder.java
+++ b/scaffold-faces/src/main/java/org/jboss/forge/scaffold/faces/metawidget/widgetbuilder/RemoveEntityWidgetBuilder.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.scaffold.faces.metawidget.widgetbuilder;
+
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.INVERSE_FIELD;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_MANY_TO_MANY;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_MANY_TO_ONE;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_ONE_TO_MANY;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_ONE_TO_ONE;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_REL_TYPE;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.OWNING_FIELD;
+import static org.metawidget.inspector.InspectionResultConstants.ENTITY;
+import static org.metawidget.inspector.InspectionResultConstants.NAME;
+import static org.metawidget.inspector.InspectionResultConstants.PARAMETERIZED_TYPE;
+import static org.metawidget.inspector.InspectionResultConstants.TYPE;
+
+import java.awt.List;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import org.metawidget.statically.javacode.JavaStatement;
+import org.metawidget.statically.javacode.StaticJavaMetawidget;
+import org.metawidget.statically.javacode.StaticJavaStub;
+import org.metawidget.statically.javacode.StaticJavaWidget;
+import org.metawidget.util.ClassUtils;
+import org.metawidget.util.simple.StringUtils;
+import org.metawidget.widgetbuilder.iface.WidgetBuilder;
+
+/**
+ * Builds Java widgets that implement the behavior for updation of bidirectional relationships during deletion of
+ * entities.
+ * 
+ * @author Vineet Reynolds
+ */
+public class RemoveEntityWidgetBuilder implements WidgetBuilder<StaticJavaWidget, StaticJavaMetawidget>
+{
+
+   @Override
+   public StaticJavaWidget buildWidget(String elementName, Map<String, String> attributes,
+            StaticJavaMetawidget metawidget)
+   {
+      if (ENTITY.equals(elementName))
+      {
+         return null;
+      }
+
+      String name = attributes.get(NAME);
+      String type = attributes.get(TYPE);
+      boolean oneToOne = attributes.get(JPA_REL_TYPE) != null && attributes.get(JPA_REL_TYPE).equals(JPA_ONE_TO_ONE);
+      boolean manyToOne = attributes.get(JPA_REL_TYPE) != null && attributes.get(JPA_REL_TYPE).equals(JPA_MANY_TO_ONE);
+      boolean oneToMany = attributes.get(JPA_REL_TYPE) != null && attributes.get(JPA_REL_TYPE).equals(JPA_ONE_TO_MANY);
+      boolean manyToMany = attributes.get(JPA_REL_TYPE) != null
+               && attributes.get(JPA_REL_TYPE).equals(JPA_MANY_TO_MANY);
+      String ownerField = attributes.get(OWNING_FIELD);
+      String inverseField = attributes.get(INVERSE_FIELD);
+
+      String capitalizedName = StringUtils.capitalize(name);
+      if (oneToOne && ownerField != null && inverseField != null)
+      {
+         StaticJavaStub toReturn = new StaticJavaStub();
+         JavaStatement getValue = new JavaStatement(ClassUtils.getSimpleName(type) + " " + name
+                  + " = deletableEntity.get"
+                  + capitalizedName + "()");
+         getValue.putImport(type);
+         toReturn.getChildren().add(getValue);
+         String fieldToNullify = name.equals(ownerField) ? inverseField : ownerField;
+         JavaStatement removeRelationship = new JavaStatement("deletableEntity.set"
+                  + StringUtils.capitalize(fieldToNullify)
+                  + "(null)");
+         toReturn.getChildren().add(removeRelationship);
+         JavaStatement mergeModification = new JavaStatement("this.entityManager.merge(" + name + ")");
+         toReturn.getChildren().add(mergeModification);
+         return toReturn;
+      }
+      else if (manyToOne && inverseField != null)
+      {
+         StaticJavaStub toReturn = new StaticJavaStub();
+         JavaStatement getValue = new JavaStatement(ClassUtils.getSimpleName(type) + " " + name
+                  + " = deletableEntity.get"
+                  + capitalizedName + "()");
+         getValue.putImport(type);
+         toReturn.getChildren().add(getValue);
+         JavaStatement removeInverse = new JavaStatement(name + ".get"
+                  + StringUtils.capitalize(inverseField)
+                  + "().remove(deletableEntity)");
+         toReturn.getChildren().add(removeInverse);
+         JavaStatement nullOwner = new JavaStatement("deletableEntity.set" + capitalizedName + "(null)");
+         toReturn.getChildren().add(nullOwner);
+         JavaStatement mergeModification = new JavaStatement("this.entityManager.merge(" + name + ")");
+         toReturn.getChildren().add(mergeModification);
+         return toReturn;
+      }
+      else if (oneToMany && ownerField != null)
+      {
+         if (type.equals(Collection.class.getName()) || type.equals(Set.class.getName())
+                  || type.equals(List.class.getName()))
+         {
+            String parameterizedType = attributes.get(PARAMETERIZED_TYPE);
+            String simpleParameterizedType = ClassUtils.getSimpleName(parameterizedType);
+
+            StaticJavaStub toReturn = new StaticJavaStub();
+            JavaStatement iterator = new JavaStatement("Iterator<" + simpleParameterizedType + "> iter"
+                     + capitalizedName + " = deletableEntity.get"
+                     + capitalizedName + "().iterator()");
+            iterator.putImport(Iterator.class.getName());
+            iterator.putImport(parameterizedType);
+            toReturn.getChildren().add(iterator);
+
+            JavaStatement collectionModifiers = new JavaStatement("for (; iter" + capitalizedName + ".hasNext() ;) ");
+
+            String scopedVariable = StringUtils.decapitalize(simpleParameterizedType);
+            JavaStatement iterable = new JavaStatement(simpleParameterizedType + " " + scopedVariable
+                     + " = iter" + capitalizedName + ".next()");
+            collectionModifiers.getChildren().add(iterable);
+
+            JavaStatement nullOwner = new JavaStatement(scopedVariable + ".set"
+                     + StringUtils.capitalize(ownerField)
+                     + "(null)");
+            collectionModifiers.getChildren().add(nullOwner);
+
+            JavaStatement removeInverse = new JavaStatement("iter" + capitalizedName + ".remove()");
+            collectionModifiers.getChildren().add(removeInverse);
+
+            JavaStatement mergeModification = new JavaStatement("this.entityManager.merge(" + scopedVariable + ")");
+            collectionModifiers.getChildren().add(mergeModification);
+
+            toReturn.getChildren().add(collectionModifiers);
+            return toReturn;
+         }
+      }
+      else if (manyToMany && ownerField != null && inverseField != null)
+      {
+         if (type.equals(Collection.class.getName()) || type.equals(Set.class.getName())
+                  || type.equals(List.class.getName()))
+         {
+            String parameterizedType = attributes.get(PARAMETERIZED_TYPE);
+            String simpleParameterizedType = ClassUtils.getSimpleName(parameterizedType);
+
+            StaticJavaStub toReturn = new StaticJavaStub();
+            JavaStatement iterator = new JavaStatement("Iterator<" + simpleParameterizedType + "> iter"
+                     + capitalizedName + " = deletableEntity.get"
+                     + capitalizedName + "().iterator()");
+            iterator.putImport(Iterator.class.getName());
+            iterator.putImport(parameterizedType);
+            toReturn.getChildren().add(iterator);
+
+            JavaStatement collectionModifiers = new JavaStatement("for (; iter" + capitalizedName + ".hasNext() ;) ");
+
+            String scopedVariable = StringUtils.decapitalize(simpleParameterizedType);
+            JavaStatement iterable = new JavaStatement(simpleParameterizedType + " " + scopedVariable
+                     + " = iter" + capitalizedName + ".next()");
+            collectionModifiers.getChildren().add(iterable);
+
+            String collectionToModify = name.equals(ownerField) ? inverseField : ownerField;
+            JavaStatement removeOtherMember = new JavaStatement(scopedVariable + ".get"
+                     + StringUtils.capitalize(collectionToModify)
+                     + "().remove(deletableEntity)");
+            collectionModifiers.getChildren().add(removeOtherMember);
+
+            JavaStatement removeInverse = new JavaStatement("iter" + capitalizedName + ".remove()");
+            collectionModifiers.getChildren().add(removeInverse);
+
+            JavaStatement mergeModification = new JavaStatement("this.entityManager.merge(" + scopedVariable + ")");
+            collectionModifiers.getChildren().add(mergeModification);
+
+            toReturn.getChildren().add(collectionModifiers);
+            return toReturn;
+         }
+      }
+      return new StaticJavaStub();
+   }
+
+}

--- a/scaffold-faces/src/main/resources/scaffold/faces/BackingBean.jv
+++ b/scaffold-faces/src/main/resources/scaffold/faces/BackingBean.jv
@@ -24,7 +24,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import @{entity.getQualifiedName()}@{qbeMetawidgetImports};
+import @{entity.getQualifiedName()}@{metawidgetImports};
 
 /**
  * Backing bean for @{entity.getName()} entities.
@@ -122,7 +122,9 @@ public class @{entity.getName()}Bean implements Serializable {
 		this.conversation.end();
 
 		try {
-			this.entityManager.remove(findById(getId()));
+		    @{entity.getName()} deletableEntity = findById(getId());
+            @{rmEntityMetawidget}
+			this.entityManager.remove(deletableEntity);
 			this.entityManager.flush();
 			return "search?faces-redirect=true";
 		} catch( Exception e ) {

--- a/scaffold-faces/src/main/resources/scaffold/faces/metawidget-remove-entity.xml
+++ b/scaffold-faces/src/main/resources/scaffold/faces/metawidget-remove-entity.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<metawidget xmlns="http://metawidget.org"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:processor="java:org.metawidget.statically.faces.component.widgetprocessor"
+            xsi:schemaLocation="http://metawidget.org http://metawidget.org/xsd/metawidget-1.0.xsd
+						java:org.metawidget.statically.faces.component.html http://metawidget.org/xsd/org.metawidget.statically.faces.component.html-1.0.xsd
+						java:org.metawidget.inspector.composite http://metawidget.org/xsd/org.metawidget.inspector.composite-1.0.xsd"
+            version="1.0">
+
+	<!-- metawidget-remove-entity.xml is used to generate the Java code for removal of JPA entities -->
+	
+        <staticJavaMetawidget xmlns="java:org.metawidget.statically.javacode">
+	
+                <inspector>
+                        <compositeInspector xmlns="java:org.metawidget.inspector.composite" config="CompositeInspectorConfig">
+                                <inspectors>
+                                        <array>
+                                                <propertyTypeInspector xmlns="java:org.metawidget.inspector.propertytype" config="org.metawidget.inspector.impl.BaseObjectInspectorConfig">
+                                                        <propertyStyle>
+                                                                <forgePropertyStyle id="forgePropertyStyle" xmlns="java:org.jboss.forge.scaffold.faces.metawidget.inspector.propertystyle" config="ForgePropertyStyleConfig">
+                                                                        <project>
+                                                                                <forgeProject/>
+                                                                        </project>
+                                                                </forgePropertyStyle>
+                                                        </propertyStyle>
+                                                </propertyTypeInspector>
+                                                <forgeInspector xmlns="java:org.jboss.forge.scaffold.faces.metawidget.inspector" config="org.metawidget.inspector.impl.BaseObjectInspectorConfig">
+                                                        <propertyStyle>
+                                                                <forgePropertyStyle refId="forgePropertyStyle"/>
+                                                        </propertyStyle>
+                                                </forgeInspector>
+                                                <jpaInspector xmlns="java:org.metawidget.inspector.jpa" config="JpaInspectorConfig">
+                                                        <propertyStyle>
+                                                                <forgePropertyStyle refId="forgePropertyStyle"/>
+                                                        </propertyStyle>
+                                                </jpaInspector>
+                                                <beanValidationInspector xmlns="java:org.metawidget.inspector.beanvalidation" config="org.metawidget.inspector.impl.BaseObjectInspectorConfig">
+                                                        <propertyStyle>
+                                                                <forgePropertyStyle refId="forgePropertyStyle"/>
+                                                        </propertyStyle>
+                                                </beanValidationInspector>
+                                        </array>
+                                </inspectors>
+                        </compositeInspector>
+                </inspector>
+                
+                <widgetBuilder>
+                        <removeEntityWidgetBuilder xmlns="java:org.jboss.forge.scaffold.faces.metawidget.widgetbuilder"/>
+                </widgetBuilder>
+
+        </staticJavaMetawidget>			
+
+</metawidget>

--- a/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/metawidget/inspector/ForgeInspectorTest.java
+++ b/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/metawidget/inspector/ForgeInspectorTest.java
@@ -6,8 +6,15 @@
  */
 package org.jboss.forge.scaffold.faces.metawidget.inspector;
 
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.INVERSE_FIELD;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_MANY_TO_MANY;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_MANY_TO_ONE;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_ONE_TO_MANY;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_ONE_TO_ONE;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_REL_TYPE;
 import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.N_TO_MANY;
 import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.ONE_TO_ONE;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.OWNING_FIELD;
 import static org.metawidget.inspector.InspectionResultConstants.ENTITY;
 import static org.metawidget.inspector.InspectionResultConstants.NAME;
 import static org.metawidget.inspector.InspectionResultConstants.PROPERTY;
@@ -51,40 +58,60 @@ public class ForgeInspectorTest
       assertEquals(PROPERTY, property.getNodeName());
       assertEquals("embedded", property.getAttribute(NAME));
       assertEquals(TRUE, property.getAttribute(ONE_TO_ONE));
-      assertEquals(2, property.getAttributes().getLength());
+      assertEquals(JPA_ONE_TO_ONE, property.getAttribute(JPA_REL_TYPE));
+      assertEquals(3, property.getAttributes().getLength());
 
       property = XmlUtils.getNextSiblingElement(property);
       assertEquals(PROPERTY, property.getNodeName());
       assertEquals("manyToMany", property.getAttribute(NAME));
       assertEquals(TRUE, property.getAttribute(N_TO_MANY));
-      assertEquals(2, property.getAttributes().getLength());
+      assertEquals(JPA_MANY_TO_MANY, property.getAttribute(JPA_REL_TYPE));
+      assertEquals(3, property.getAttributes().getLength());
 
       property = XmlUtils.getNextSiblingElement(property);
       assertEquals(PROPERTY, property.getNodeName());
       assertEquals("manyToOne", property.getAttribute(NAME));
       assertEquals("#{forgeInspectorTest$BarBean.all}", property.getAttribute(FACES_LOOKUP));
       assertEquals("#{forgeInspectorTest$BarBean.converter}", property.getAttribute(FACES_CONVERTER_ID));
-      assertEquals(3, property.getAttributes().getLength());
+      assertEquals(JPA_MANY_TO_ONE, property.getAttribute(JPA_REL_TYPE));
+      assertEquals(5, property.getAttributes().getLength());
 
+      property = XmlUtils.getNextSiblingElement(property);
+      assertEquals(PROPERTY, property.getNodeName());
+      assertEquals("manyToOneBidi", property.getAttribute(NAME));
+      assertEquals("#{forgeInspectorTest$BarBean.all}", property.getAttribute(FACES_LOOKUP));
+      assertEquals("#{forgeInspectorTest$BarBean.converter}", property.getAttribute(FACES_CONVERTER_ID));
+      assertEquals("foos", property.getAttribute(INVERSE_FIELD));
+      assertEquals("manyToOneBidi", property.getAttribute(OWNING_FIELD));
+      assertEquals(JPA_MANY_TO_ONE, property.getAttribute(JPA_REL_TYPE));
+      assertEquals(6, property.getAttributes().getLength());
+      
       property = XmlUtils.getNextSiblingElement(property);
       assertEquals(PROPERTY, property.getNodeName());
       assertEquals("oneToMany", property.getAttribute(NAME));
       assertEquals(TRUE, property.getAttribute(N_TO_MANY));
-      assertEquals(2, property.getAttributes().getLength());
+      assertEquals("oneToMany", property.getAttribute(INVERSE_FIELD));
+      assertEquals("bar", property.getAttribute(OWNING_FIELD));
+      assertEquals(JPA_ONE_TO_MANY, property.getAttribute(JPA_REL_TYPE));
+      assertEquals(5, property.getAttributes().getLength());
 
       property = XmlUtils.getNextSiblingElement(property);
       assertEquals(PROPERTY, property.getNodeName());
       assertEquals("oneToOne", property.getAttribute(NAME));
       assertEquals(TRUE, property.getAttribute(ONE_TO_ONE));
-      assertEquals(2, property.getAttributes().getLength());
+      assertEquals(JPA_ONE_TO_ONE, property.getAttribute(JPA_REL_TYPE));
+      assertEquals(3, property.getAttributes().getLength());
 
       property = XmlUtils.getNextSiblingElement(property);
       assertEquals(PROPERTY, property.getNodeName());
       assertEquals("oneToOneMappedBy", property.getAttribute(NAME));
       assertEquals(TRUE, property.getAttribute(ONE_TO_ONE));
-      assertEquals(2, property.getAttributes().getLength());
+      assertEquals("oneToOneMappedBy", property.getAttribute(INVERSE_FIELD));
+      assertEquals("foo", property.getAttribute(OWNING_FIELD));
+      assertEquals(JPA_ONE_TO_ONE, property.getAttribute(JPA_REL_TYPE));
+      assertEquals(5, property.getAttributes().getLength());
 
-      assertEquals(6, entity.getChildNodes().getLength());
+      assertEquals(7, entity.getChildNodes().getLength());
    }
 
    //
@@ -122,9 +149,15 @@ public class ForgeInspectorTest
 
          return null;
       }
+      
+      @ManyToOne
+      public Bar getManyToOneBidi() {
+
+         return null;
+      }
 
       @ManyToMany
-      public Bar getManyToMany() {
+      public Set<Bar> getManyToMany() {
 
          return null;
       }
@@ -133,6 +166,24 @@ public class ForgeInspectorTest
    static class Bar
    {
       public String getName() {
+
+         return null;
+      }
+      
+      @OneToOne()
+      public Foo getFoo()
+      {
+         return null;
+      }
+      
+      @ManyToOne()
+      public Foo getBar()
+      {
+         return null;
+      }
+      
+      @OneToMany(mappedBy="manyToOneBidi")
+      public Set<Foo> getFoos() {
 
          return null;
       }

--- a/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/metawidget/widgetbuilder/RemoveEntityWidgetBuilderTest.java
+++ b/scaffold-faces/src/test/java/org/jboss/forge/scaffold/faces/metawidget/widgetbuilder/RemoveEntityWidgetBuilderTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.scaffold.faces.metawidget.widgetbuilder;
+
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.INVERSE_FIELD;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_MANY_TO_MANY;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_MANY_TO_ONE;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_ONE_TO_MANY;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_ONE_TO_ONE;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.JPA_REL_TYPE;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.N_TO_MANY;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.ONE_TO_ONE;
+import static org.jboss.forge.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.OWNING_FIELD;
+import static org.junit.Assert.*;
+import static org.metawidget.inspector.InspectionResultConstants.NAME;
+import static org.metawidget.inspector.InspectionResultConstants.PARAMETERIZED_TYPE;
+import static org.metawidget.inspector.InspectionResultConstants.PROPERTY;
+import static org.metawidget.inspector.InspectionResultConstants.READ_ONLY;
+import static org.metawidget.inspector.InspectionResultConstants.TRUE;
+import static org.metawidget.inspector.InspectionResultConstants.TYPE;
+import static org.metawidget.inspector.faces.StaticFacesInspectionResultConstants.FACES_LOOKUP;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.metawidget.statically.javacode.StaticJavaMetawidget;
+import org.metawidget.util.CollectionUtils;
+
+public class RemoveEntityWidgetBuilderTest
+{
+
+   @Test
+   public void testRemoveEntityNoRelation() throws Exception
+   {
+      RemoveEntityWidgetBuilder widgetBuilder = new RemoveEntityWidgetBuilder();
+      Map<String, String> attributes = CollectionUtils.newHashMap();
+      attributes.put(NAME, "bar");
+      attributes.put(TYPE, "com.acme.Example");
+      attributes.put(READ_ONLY, TRUE);
+      attributes.put(FACES_LOOKUP, "#{barBean.all}");
+      assertEquals("", widgetBuilder.buildWidget(PROPERTY, attributes, new StaticJavaMetawidget()).toString());
+   }
+   
+   @Test
+   public void testRemoveEntityUniOneToOneRelation() throws Exception
+   {
+      RemoveEntityWidgetBuilder widgetBuilder = new RemoveEntityWidgetBuilder();
+      Map<String, String> attributes = CollectionUtils.newHashMap();
+      attributes.put(NAME, "foo");
+      attributes.put(TYPE, "com.acme.Example");
+      attributes.put(ONE_TO_ONE, TRUE);
+      attributes.put(JPA_REL_TYPE, JPA_ONE_TO_ONE);
+      assertEquals("", widgetBuilder.buildWidget(PROPERTY, attributes, new StaticJavaMetawidget()).toString());
+   }
+   
+   @Test
+   public void testRemoveEntityBidiOneToOneRelationOwningSide() throws Exception
+   {
+      RemoveEntityWidgetBuilder widgetBuilder = new RemoveEntityWidgetBuilder();
+      Map<String, String> attributes = CollectionUtils.newHashMap();
+      attributes.put(NAME, "foo");
+      attributes.put(TYPE, "com.acme.Example");
+      attributes.put(ONE_TO_ONE, TRUE);
+      attributes.put(JPA_REL_TYPE, JPA_ONE_TO_ONE);
+      attributes.put(OWNING_FIELD, "foo");
+      attributes.put(INVERSE_FIELD, "bar");
+      assertEquals(
+               "Example foo = deletableEntity.getFoo();deletableEntity.setBar(null);this.entityManager.merge(foo);",
+               widgetBuilder.buildWidget(PROPERTY, attributes, new StaticJavaMetawidget()).toString());
+   }
+
+   @Test
+   public void testRemoveEntityBidiOneToOneRelationInverseSide() throws Exception
+   {
+      RemoveEntityWidgetBuilder widgetBuilder = new RemoveEntityWidgetBuilder();
+      Map<String, String> attributes = CollectionUtils.newHashMap();
+      attributes.put(NAME, "bar");
+      attributes.put(TYPE, "com.acme.Example");
+      attributes.put(ONE_TO_ONE, TRUE);
+      attributes.put(JPA_REL_TYPE, JPA_ONE_TO_ONE);
+      attributes.put(OWNING_FIELD, "foo");
+      attributes.put(INVERSE_FIELD, "bar");
+      assertEquals(
+               "Example bar = deletableEntity.getBar();deletableEntity.setFoo(null);this.entityManager.merge(bar);",
+               widgetBuilder.buildWidget(PROPERTY, attributes, new StaticJavaMetawidget()).toString());
+   }
+   
+   @Test
+   public void testRemoveEntityUniOneToManyRelation() throws Exception
+   {
+      RemoveEntityWidgetBuilder widgetBuilder = new RemoveEntityWidgetBuilder();
+      Map<String, String> attributes = CollectionUtils.newHashMap();
+      attributes.put(NAME, "bar");
+      attributes.put(TYPE, "java.util.Set");
+      attributes.put(PARAMETERIZED_TYPE, "com.acme.Example");
+      attributes.put(N_TO_MANY, TRUE);
+      attributes.put(JPA_REL_TYPE, JPA_ONE_TO_MANY);
+      assertEquals("", widgetBuilder.buildWidget(PROPERTY, attributes, new StaticJavaMetawidget()).toString());
+   }
+
+   @Test
+   public void testRemoveEntityBidiOneToManyRelationInverseSide() throws Exception
+   {
+      RemoveEntityWidgetBuilder widgetBuilder = new RemoveEntityWidgetBuilder();
+      Map<String, String> attributes = CollectionUtils.newHashMap();
+      attributes.put(NAME, "bar");
+      attributes.put(TYPE, "java.util.Set");
+      attributes.put(PARAMETERIZED_TYPE, "com.acme.Example");
+      attributes.put(N_TO_MANY, TRUE);
+      attributes.put(JPA_REL_TYPE, JPA_ONE_TO_MANY);
+      attributes.put(OWNING_FIELD, "foo");
+      attributes.put(INVERSE_FIELD, "bar");
+      assertEquals(
+               "Iterator<Example> iterBar = deletableEntity.getBar().iterator();for (; iterBar.hasNext() ;)  { Example example = iterBar.next();example.setFoo(null);iterBar.remove();this.entityManager.merge(example); }",
+               widgetBuilder.buildWidget(PROPERTY, attributes, new StaticJavaMetawidget()).toString());
+   }
+
+   @Test
+   public void testRemoveEntityUniManyToOneRelation() throws Exception
+   {
+      RemoveEntityWidgetBuilder widgetBuilder = new RemoveEntityWidgetBuilder();
+      Map<String, String> attributes = CollectionUtils.newHashMap();
+      attributes.put(NAME, "bar");
+      attributes.put(TYPE, "com.acme.Example");
+      attributes.put(JPA_REL_TYPE, JPA_MANY_TO_ONE);
+      assertEquals("", widgetBuilder.buildWidget(PROPERTY, attributes, new StaticJavaMetawidget()).toString());
+   }
+   
+   @Test
+   public void testRemoveEntityBidiManyToOneRelationOwningSide() throws Exception
+   {
+      RemoveEntityWidgetBuilder widgetBuilder = new RemoveEntityWidgetBuilder();
+      Map<String, String> attributes = CollectionUtils.newHashMap();
+      attributes.put(NAME, "bar");
+      attributes.put(TYPE, "com.acme.Example");
+      attributes.put(JPA_REL_TYPE, JPA_MANY_TO_ONE);
+      attributes.put(OWNING_FIELD, "bar");
+      attributes.put(INVERSE_FIELD, "foo");
+      assertEquals(
+               "Example bar = deletableEntity.getBar();bar.getFoo().remove(deletableEntity);deletableEntity.setBar(null);this.entityManager.merge(bar);",
+               widgetBuilder.buildWidget(PROPERTY, attributes, new StaticJavaMetawidget()).toString());
+   }
+   
+   @Test
+   public void testRemoveEntityUniManyToManyRelation() throws Exception
+   {
+      RemoveEntityWidgetBuilder widgetBuilder = new RemoveEntityWidgetBuilder();
+      Map<String, String> attributes = CollectionUtils.newHashMap();
+      attributes.put(NAME, "bar");
+      attributes.put(TYPE, "java.util.Set");
+      attributes.put(PARAMETERIZED_TYPE, "com.acme.Example");
+      attributes.put(N_TO_MANY, TRUE);
+      attributes.put(JPA_REL_TYPE, JPA_MANY_TO_MANY);
+      assertEquals("", widgetBuilder.buildWidget(PROPERTY, attributes, new StaticJavaMetawidget()).toString());
+   }
+
+   @Test
+   public void testRemoveEntityBidiManyToManyRelationInverseSide() throws Exception
+   {
+      RemoveEntityWidgetBuilder widgetBuilder = new RemoveEntityWidgetBuilder();
+      Map<String, String> attributes = CollectionUtils.newHashMap();
+      attributes.put(NAME, "bar");
+      attributes.put(TYPE, "java.util.Set");
+      attributes.put(PARAMETERIZED_TYPE, "com.acme.Example");
+      attributes.put(N_TO_MANY, TRUE);
+      attributes.put(JPA_REL_TYPE, JPA_MANY_TO_MANY);
+      attributes.put(OWNING_FIELD, "foo");
+      attributes.put(INVERSE_FIELD, "bar");
+      assertEquals(
+               "Iterator<Example> iterBar = deletableEntity.getBar().iterator();for (; iterBar.hasNext() ;)  { Example example = iterBar.next();example.getFoo().remove(deletableEntity);iterBar.remove();this.entityManager.merge(example); }",
+               widgetBuilder.buildWidget(PROPERTY, attributes, new StaticJavaMetawidget()).toString());
+   }
+
+   @Test
+   public void testRemoveEntityBidiManyToManyRelationOwningSide() throws Exception
+   {
+      RemoveEntityWidgetBuilder widgetBuilder = new RemoveEntityWidgetBuilder();
+      Map<String, String> attributes = CollectionUtils.newHashMap();
+      attributes.put(NAME, "foo");
+      attributes.put(TYPE, "java.util.Set");
+      attributes.put(PARAMETERIZED_TYPE, "com.acme.Example");
+      attributes.put(N_TO_MANY, TRUE);
+      attributes.put(JPA_REL_TYPE, JPA_MANY_TO_MANY);
+      attributes.put(OWNING_FIELD, "foo");
+      attributes.put(INVERSE_FIELD, "bar");
+      assertEquals(
+               "Iterator<Example> iterFoo = deletableEntity.getFoo().iterator();for (; iterFoo.hasNext() ;)  { Example example = iterFoo.next();example.getBar().remove(deletableEntity);iterFoo.remove();this.entityManager.merge(example); }",
+               widgetBuilder.buildWidget(PROPERTY, attributes, new StaticJavaMetawidget()).toString());
+   }
+}


### PR DESCRIPTION
Added support into ForgeInspector to detect the owning and inverse sides of a bi-directional relationship.

Based on the availability of these attributes during the RemoveEntityWidget Metawidget construction, enhanced deletion logic is made available given the knowledege of the bidirectional relationships. The relationships are modified in both directions during deletion of a JPA entity.
