### PR TITLE
FORGE-979 Fixed Forge plugin installation failures on Windows.

### DIFF
--- a/git-tools/src/main/java/org/jboss/forge/git/GitUtils.java
+++ b/git-tools/src/main/java/org/jboss/forge/git/GitUtils.java
@@ -372,8 +372,17 @@ public abstract class GitUtils
       return newBranch;
    }
 
+   /**
+    * Closes a Git repository.
+    * Invoke this before deleting the Git repository on Windows to prevent errors due to unclosed file handles.  
+    * 
+    * @param repo The repository to close.
+    */
    public static void close(final Git repo)
    {
-      repo.getRepository().close();
+      if (repo != null)
+      {
+         repo.getRepository().close();
+      }
    }
 }

--- a/shell/src/main/java/org/jboss/forge/shell/plugins/builtin/ForgePlugin.java
+++ b/shell/src/main/java/org/jboss/forge/shell/plugins/builtin/ForgePlugin.java
@@ -307,11 +307,12 @@ public class ForgePlugin implements Plugin
          buildDir = shell.getCurrentDirectory().createTempResource();
       }
 
+      Git repo = null;
       try
       {
          ShellMessages.info(out, "Checking out plugin source files to [" + buildDir.getFullyQualifiedName()
                   + "] via 'git'");
-         Git repo = GitUtils.clone(buildDir, gitRepo);
+         repo = GitUtils.clone(buildDir, gitRepo);
 
          Ref ref = null;
          String targetRef = refName;
@@ -414,6 +415,7 @@ public class ForgePlugin implements Plugin
       }
       finally
       {
+         GitUtils.close(repo);
          if (buildDir != null)
          {
             if (keepSources)


### PR DESCRIPTION
The fix was to close the Git repository before deleting the directory housing it.
