### PR TITLE
FORGE-593 Converted the console input queue to a shared one.

### DIFF
--- a/shell/src/main/java/org/jboss/forge/shell/buffers/ConsoleInputSession.java
+++ b/shell/src/main/java/org/jboss/forge/shell/buffers/ConsoleInputSession.java
@@ -21,7 +21,14 @@ public class ConsoleInputSession
    private InputStream consoleStream;
    private InputStream externalInputStream;
 
-   private final ArrayBlockingQueue<String> blockingQueue = new ArrayBlockingQueue<String>(1000);
+   /*
+    * A queue to hold characters that have been read from the raw console. This is declared as static, as a hack, to
+    * allow characters to be read by an eventually terminating reader thread without being lost. This is necessary due
+    * to the blocking read on System.in in the reader thread. One reader thread can be blocked reading System.in while
+    * awaiting termination during an internal restart of Forge, and another reader thread would have just started but
+    * would be awaiting the lock on System.in.
+    */
+   private static final ArrayBlockingQueue<String> blockingQueue = new ArrayBlockingQueue<String>(1000);
 
    private volatile boolean connected;
 
@@ -45,7 +52,7 @@ public class ConsoleInputSession
                   b = blockingQueue.poll(365, TimeUnit.DAYS);
                   c = 0;
                }
-
+               
                if (b != null)
                {
                   return b.charAt(c++);
@@ -110,7 +117,6 @@ public class ConsoleInputSession
    public void stop()
    {
       connected = false;
-      blockingQueue.offer("");
    }
 
    public InputStream getExternalInputStream()


### PR DESCRIPTION
The blocking queue in ConsoleInputSession is converted to a static shared queue to ensure that characters input by a user that are captured by an eventually terminating reader thread will not be lost (by pushing them in a per-thread queue). Instead, the characters are now pushed into a shared queue where they may be read without any loss.

This is a hack to ensure that characters are not lost. Ideally, in a multiple reader thread situation, this should have been done by ensuring that the reader thread obtained just the right number of characters from System.in and eventually terminated gracefully. But, reads on System.in are blocking by nature, and Windows does not provide information on the number of characters to be read via InputStream.available(). Hence the hack.
