### PR TITLE
FORGE-1006 Added a plugin to aid in updating of JPA entities.

### DIFF
--- a/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/UpdateEntityPlugin.java
+++ b/javaee-impl/src/main/java/org/jboss/forge/spec/javaee/jpa/UpdateEntityPlugin.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.spec.javaee.jpa;
+
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Transient;
+import javax.persistence.Version;
+
+import org.jboss.forge.parser.java.Field;
+import org.jboss.forge.parser.java.JavaClass;
+import org.jboss.forge.parser.java.JavaSource;
+import org.jboss.forge.parser.java.Type;
+import org.jboss.forge.parser.java.util.Refactory;
+import org.jboss.forge.project.Project;
+import org.jboss.forge.project.facets.JavaSourceFacet;
+import org.jboss.forge.resources.Resource;
+import org.jboss.forge.resources.java.JavaResource;
+import org.jboss.forge.shell.Shell;
+import org.jboss.forge.shell.ShellMessages;
+import org.jboss.forge.shell.ShellPrintWriter;
+import org.jboss.forge.shell.plugins.Alias;
+import org.jboss.forge.shell.plugins.Command;
+import org.jboss.forge.shell.plugins.Current;
+import org.jboss.forge.shell.plugins.Help;
+import org.jboss.forge.shell.plugins.Option;
+import org.jboss.forge.shell.plugins.Plugin;
+import org.jboss.forge.shell.plugins.RequiresFacet;
+import org.jboss.forge.shell.plugins.RequiresProject;
+import org.jboss.forge.spec.javaee.PersistenceFacet;
+
+@Alias("update-entity")
+@RequiresProject
+@RequiresFacet(PersistenceFacet.class)
+@Help("A plugin to aid in refactoring of JPA @Entity classes.")
+public class UpdateEntityPlugin implements Plugin
+{
+
+   @Inject
+   @Current
+   private Resource<?> currentResource;
+
+   @Inject
+   private Project project;
+
+   @Inject
+   private ShellPrintWriter writer;
+
+   @Inject
+   private Shell shell;
+
+   @Command(value = "hashcode-and-equals", help = "Create or updates the hashCode() and equals() methods for JPA @Entities")
+   public void createOrUpdateHashCodeAndEquals(
+            @Option(required = false,
+                     description = "The JPA @Entity classes") JavaResource[] resources) throws Throwable
+   {
+      if (((resources == null) || (resources.length < 1)) && (currentResource instanceof JavaResource))
+      {
+         resources = new JavaResource[] { (JavaResource) currentResource };
+      }
+
+      List<JavaResource> entities = selectEntities(resources);
+      if (entities.isEmpty())
+      {
+         ShellMessages.error(writer, "Must specify atleast one @Entity class on which to operate.");
+         return;
+      }
+
+      JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
+      for (JavaResource resource : resources)
+      {
+         JavaClass entity = (JavaClass) (resource).getJavaSource();
+
+         Set<Field<?>> selectedFields = new HashSet<Field<?>>();
+         Map<String, Field<?>> candidateFields = getCandidateFields(entity);
+         selectedFields = shell.promptMultiSelectWithWildcard("*",
+                  "Choose the fields to use in the equals and hashCode methods. Use * to select all.",
+                  candidateFields);
+         warnIncorrectFields(entity, selectedFields);
+         overwriteMethods(entity);
+         Refactory.createHashCodeAndEquals(entity, selectedFields.toArray(new Field<?>[selectedFields.size()]));
+         java.saveJavaSource(entity);
+         shell.println("Added equals() and hashCode() in [" + entity.getQualifiedName() + "].");
+      }
+   }
+
+   private void overwriteMethods(JavaClass entity)
+   {
+      if (entity.hasMethodSignature("equals", Object.class))
+      {
+         entity.removeMethod(entity.getMethod("equals", Object.class));
+      }
+      if (entity.hasMethodSignature("hashCode"))
+      {
+         entity.removeMethod(entity.getMethod("hashCode"));
+      }
+   }
+
+   private Map<String, Field<?>> getCandidateFields(JavaClass entity)
+   {
+      Map<String, Field<?>> candidateFields = new HashMap<String,Field<?>>();
+      for (Field<?> field : entity.getFields())
+      {
+         // Skip static fields
+         if (field.isStatic())
+         {
+            continue;
+         }
+
+         candidateFields.put(field.getName(),field);
+      }
+      return candidateFields;
+   }
+
+   private List<JavaResource> selectEntities(Resource<?>[] targets) throws FileNotFoundException
+   {
+      List<JavaResource> results = new ArrayList<JavaResource>();
+      for (Resource<?> r : targets)
+      {
+         if (r instanceof JavaResource)
+         {
+            JavaSource<?> entity = ((JavaResource) r).getJavaSource();
+
+            if (entity instanceof JavaClass)
+            {
+               if (entity.hasAnnotation(Entity.class))
+               {
+                  results.add((JavaResource) r);
+               }
+               else
+               {
+                  displaySkippingResourceMsg(entity);
+               }
+            }
+            else
+            {
+               displaySkippingResourceMsg(entity);
+            }
+         }
+      }
+      return results;
+   }
+
+   private void warnIncorrectFields(JavaClass entity, Set<Field<?>> selectedFields)
+   {
+      for (Field<?> field : selectedFields)
+      {
+         Type<?> typeInspector = field.getTypeInspector();
+         String fieldType = typeInspector.getQualifiedName();
+         
+         // TODO: Warn if the field is of a type that implements equals() and hashCode(). This will however depend on
+         // the ability to obtain a JavaClass instance for the type of the field.
+         if (field.isTransient() || field.hasAnnotation(Transient.class))
+         {
+            displayTransientFieldWarningMsg(entity, field);
+         }
+         if (fieldType.equals("java.util.Collection") || fieldType.equals("java.util.List")
+                  || fieldType.equals("java.util.Set") || fieldType.equals("java.util.Map"))
+         {
+            displayCollectionFieldWarningMsg(entity, field);
+         }
+         // Warn for JPA @GeneratedValue @Version fields
+         if (field.hasAnnotation(GeneratedValue.class))
+         {
+            displayGeneratedValueFieldWarningMsg(entity, field);
+         }
+         if(field.hasAnnotation(Version.class))
+         {
+            displayVersionFieldWarningMsg(entity, field);
+         }
+      }
+   }
+   
+   private void displayGeneratedValueFieldWarningMsg(JavaClass klass, Field<?> field)
+   {
+      ShellMessages.warn(writer, "A field [" + field.getName()
+               + "] having the @GeneratedValue annotation was chosen. The generated equals() and hashCode() methods for the class [" + klass.getName()
+               + "] may be incorrect.");
+   }
+   
+   private void displayVersionFieldWarningMsg(JavaClass klass, Field<?> field)
+   {
+      ShellMessages.warn(writer, "A field [" + field.getName()
+               + "] having the @Version annotation was chosen. The generated equals() and hashCode() methods for the class [" + klass.getName()
+               + "] may be incorrect.");
+   }
+
+   private void displayCollectionFieldWarningMsg(JavaClass klass, Field<?> field)
+   {
+      ShellMessages.warn(writer, "A collection field [" + field.getName()
+               + "] was chosen. The generated equals() and hashCode() methods for the class [" + klass.getName()
+               + "] may be incorrect.");
+   }
+
+   private void displayTransientFieldWarningMsg(JavaClass klass, Field<?> field)
+   {
+      ShellMessages.warn(writer, "A transient field [" + field.getName()
+               + "] was chosen. The generated equals() and hashCode() methods for the class [" + klass.getName()
+               + "] may be incorrect.");
+   }
+
+   private void displaySkippingResourceMsg(final JavaSource<?> entity)
+   {
+      ShellMessages.info(writer, "Skipped non-@Entity Java resource [" + entity.getQualifiedName() + "]");
+   }
+
+}

--- a/javaee-impl/src/test/java/org/jboss/forge/spec/jpa/UpdateEntityPluginTest.java
+++ b/javaee-impl/src/test/java/org/jboss/forge/spec/jpa/UpdateEntityPluginTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.spec.jpa;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.internal.matchers.StringContains.containsString;
+
+import java.io.InputStream;
+
+import org.jboss.forge.parser.JavaParser;
+import org.jboss.forge.parser.java.JavaClass;
+import org.jboss.forge.project.Project;
+import org.jboss.forge.project.facets.JavaSourceFacet;
+import org.jboss.forge.shell.util.ConstraintInspector;
+import org.jboss.forge.spec.javaee.jpa.UpdateEntityPlugin;
+import org.junit.Test;
+
+public class UpdateEntityPluginTest extends AbstractJPATest
+{
+
+   @Test
+   public void testEqualsHashCodeWithBusinessKey() throws Exception
+   {
+      Project project = getProject();
+
+      JavaClass entity = JavaParser.parse(JavaClass.class, getTestResource("EntityWithBusinessKey.java"));
+      JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
+      java.saveJavaSource(entity);
+      String businessKeyFieldName = "userName";
+
+      queueInputLines(businessKeyFieldName, "\n");
+      getShell().execute(pluginName() + " hashcode-and-equals " + entity.getCanonicalName());
+      JavaClass javaClass = (JavaClass) java.getJavaResource(entity.getQualifiedName()).getJavaSource();
+      assertFalse(javaClass.hasSyntaxErrors());
+      assertEqualsStructureForObjects(businessKeyFieldName, javaClass);
+      assertHashCodeStructureForObjects(businessKeyFieldName, javaClass);
+   }
+
+   @Test
+   public void testEqualsHashCodeWithGeneratedValue() throws Exception
+   {
+      Project project = getProject();
+
+      String className = "EntityOnlyIdAndVersion";
+      JavaClass entity = JavaParser.parse(JavaClass.class, getTestResource(className + ".java"));
+      JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
+      java.saveJavaSource(entity);
+      String idFieldName = "id";
+
+      queueInputLines(idFieldName, "\n");
+      getShell().execute(pluginName() + " hashcode-and-equals " + entity.getCanonicalName());
+      JavaClass javaClass = (JavaClass) java.getJavaResource(entity.getQualifiedName()).getJavaSource();
+      assertFalse(javaClass.hasSyntaxErrors());
+      assertEqualsStructureForObjects(idFieldName, javaClass);
+      assertHashCodeStructureForObjects(idFieldName, javaClass);
+      assertWarningForGeneratedValue(className, idFieldName);
+   }
+
+   @Test
+   public void testEqualsHashCodeWithVersionField() throws Exception
+   {
+      Project project = getProject();
+
+      String className = "EntityOnlyIdAndVersion";
+      JavaClass entity = JavaParser.parse(JavaClass.class, getTestResource(className + ".java"));
+      JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
+      java.saveJavaSource(entity);
+      String versionFieldName = "version";
+
+      queueInputLines(versionFieldName, "\n");
+      getShell().execute(pluginName() + " hashcode-and-equals " + entity.getCanonicalName());
+      JavaClass javaClass = (JavaClass) java.getJavaResource(entity.getQualifiedName()).getJavaSource();
+      assertFalse(javaClass.hasSyntaxErrors());
+      assertEqualsStructureForPrimitives(versionFieldName, javaClass);
+      assertHashCodeStructureForPrimitives(versionFieldName, javaClass);
+      assertWarningForVersionField(className, versionFieldName);
+   }
+
+   @Test
+   public void testEqualsHashCodeWithTransient() throws Exception
+   {
+      Project project = getProject();
+
+      String className = "EntityWithTransientField";
+      JavaClass entity = JavaParser.parse(JavaClass.class, getTestResource(className + ".java"));
+      JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
+      java.saveJavaSource(entity);
+      String transientFieldName = "fullName";
+
+      queueInputLines(transientFieldName, "\n");
+      getShell().execute(pluginName() + " hashcode-and-equals " + entity.getCanonicalName());
+      JavaClass javaClass = (JavaClass) java.getJavaResource(entity.getQualifiedName()).getJavaSource();
+      assertFalse(javaClass.hasSyntaxErrors());
+      assertEqualsStructureForObjects(transientFieldName, javaClass);
+      assertHashCodeStructureForObjects(transientFieldName, javaClass);
+      assertWarningForTransientField(className, transientFieldName);
+   }
+
+   @Test
+   public void testEqualsHashCodeWithCollection() throws Exception
+   {
+      Project project = getProject();
+
+      String className = "EntityWithCollection";
+      JavaClass entity = JavaParser.parse(JavaClass.class, getTestResource(className + ".java"));
+      JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
+      java.saveJavaSource(entity);
+      JavaClass association = JavaParser.parse(JavaClass.class, getTestResource("Association.java"));
+      java.saveJavaSource(association);
+      String collectionFieldName = "associations";
+
+      queueInputLines(collectionFieldName, "\n");
+      getShell().execute(pluginName() + " hashcode-and-equals " + entity.getCanonicalName());
+      JavaClass javaClass = (JavaClass) java.getJavaResource(entity.getQualifiedName()).getJavaSource();
+      assertFalse(javaClass.hasSyntaxErrors());
+      assertEqualsStructureForObjects(collectionFieldName, javaClass);
+      assertHashCodeStructureForObjects(collectionFieldName, javaClass);
+      assertWarningForCollectionField(className, collectionFieldName);
+   }
+
+   @Test
+   public void testEqualsHashCodeWithMultipleFields() throws Exception
+   {
+      Project project = getProject();
+
+      String className = "EntityWithMultipleFields";
+      JavaClass entity = JavaParser.parse(JavaClass.class, getTestResource(className +".java"));
+      JavaSourceFacet java = project.getFacet(JavaSourceFacet.class);
+      java.saveJavaSource(entity);
+      JavaClass association = JavaParser.parse(JavaClass.class, getTestResource("Association.java"));
+      java.saveJavaSource(association);
+      String idFieldName = "id";
+      String versionFieldName = "version";
+      String transientFieldName = "fullName";
+      String collectionFieldName = "associations";
+
+      queueInputLines("*", "\n");
+      getShell().execute(pluginName() + " hashcode-and-equals " + entity.getCanonicalName());
+      JavaClass javaClass = (JavaClass) java.getJavaResource(entity.getQualifiedName()).getJavaSource();
+      assertFalse(javaClass.hasSyntaxErrors());
+      assertEqualsStructureForObjects(idFieldName, javaClass);
+      assertHashCodeStructureForObjects(idFieldName, javaClass);
+      assertEqualsStructureForPrimitives(versionFieldName, javaClass);
+      assertHashCodeStructureForPrimitives(versionFieldName, javaClass);
+      assertEqualsStructureForObjects(transientFieldName, javaClass);
+      assertHashCodeStructureForObjects(transientFieldName, javaClass);
+      assertEqualsStructureForObjects(collectionFieldName, javaClass);
+      assertHashCodeStructureForObjects(collectionFieldName, javaClass);
+      
+      assertWarningForGeneratedValue(className, idFieldName);
+      assertWarningForVersionField(className, versionFieldName);
+      assertWarningForTransientField(className, transientFieldName);
+      assertWarningForCollectionField(className, collectionFieldName);
+   }
+
+   private void assertEqualsStructureForObjects(String fieldName, JavaClass javaClass)
+   {
+      assertFalse(javaClass.getMethod("equals", Object.class).getBody().isEmpty());
+      assertThat(javaClass.getMethod("equals", Object.class).getBody(), containsString("if (!" + fieldName
+               + ".equals(other." + fieldName + "))"));
+   }
+
+   private void assertEqualsStructureForPrimitives(String fieldName, JavaClass javaClass)
+   {
+      assertFalse(javaClass.getMethod("equals", Object.class).getBody().isEmpty());
+      assertThat(javaClass.getMethod("equals", Object.class).getBody(), containsString("if (" + fieldName
+               + " != other." + fieldName + ")"));
+   }
+
+   private void assertHashCodeStructureForObjects(String fieldName, JavaClass javaClass)
+   {
+      assertFalse(javaClass.getMethod("hashCode").getBody().isEmpty());
+      assertThat(javaClass.getMethod("hashCode").getBody(), containsString("result=prime * result + (("
+               + fieldName + " == null) ? 0 : " + fieldName + ".hashCode());"));
+   }
+
+   private void assertHashCodeStructureForPrimitives(String fieldName, JavaClass javaClass)
+   {
+      assertFalse(javaClass.getMethod("hashCode").getBody().isEmpty());
+      assertThat(javaClass.getMethod("hashCode").getBody(), containsString("result=prime * result + "
+               + fieldName + ";"));
+   }
+
+   private void assertWarningForGeneratedValue(String className, String fieldName)
+   {
+      assertThat(
+               getOutput(),
+               containsString("***WARNING*** A field [" + fieldName
+                        + "] having the @GeneratedValue annotation was chosen."
+                        + " The generated equals() and hashCode() methods for the class [" + className
+                        + "] may be incorrect."));
+   }
+
+   private void assertWarningForVersionField(String className, String fieldName)
+   {
+      assertThat(
+               getOutput(),
+               containsString("***WARNING*** A field [" + fieldName
+                        + "] having the @Version annotation was chosen."
+                        + " The generated equals() and hashCode() methods for the class [" + className
+                        + "] may be incorrect."));
+   }
+
+   private void assertWarningForTransientField(String className, String fieldName)
+   {
+      assertThat(
+               getOutput(),
+               containsString("***WARNING*** A transient field [" + fieldName +
+                        "] was chosen. The generated equals() and hashCode() methods for the class [" + className +
+                        "] may be incorrect."));
+   }
+
+   private void assertWarningForCollectionField(String className, String fieldName)
+   {
+      assertThat(
+               getOutput(),
+               containsString("***WARNING*** A collection field [" + fieldName
+                        + "] was chosen. The generated equals() and hashCode() methods for the class [" + className
+                        + "] may be incorrect."));
+   }
+
+   private String pluginName()
+   {
+      return ConstraintInspector.getName(UpdateEntityPlugin.class);
+   }
+
+   private InputStream getTestResource(String file)
+   {
+      return getClass().getResourceAsStream(file);
+   }
+}

--- a/javaee-impl/src/test/resources/org/jboss/forge/spec/jpa/Association.java
+++ b/javaee-impl/src/test/resources/org/jboss/forge/spec/jpa/Association.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+import javax.persistence.Entity;
+import java.io.Serializable;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Column;
+import javax.persistence.Version;
+import java.lang.Override;
+
+@Entity
+public class Association implements Serializable
+{
+
+   @Id
+   @GeneratedValue(strategy = GenerationType.AUTO)
+   @Column(name = "id", updatable = false, nullable = false)
+   private Long id = null;
+   
+   @Version
+   private @Column(name = "version")
+   int version = 0;
+   
+   public Long getId()
+   {
+      return this.id;
+   }
+
+   public void setId(final Long id)
+   {
+      this.id = id;
+   }
+
+   public int getVersion()
+   {
+      return this.version;
+   }
+
+   public void setVersion(final int version)
+   {
+      this.version = version;
+   }
+   
+   public String toString()
+   {
+      String result = "";
+      if (id != null)
+         result += id;
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object that)
+   {
+      if (this == that)
+      {
+         return true;
+      }
+      if (that == null)
+      {
+         return false;
+      }
+      if (getClass() != that.getClass())
+      {
+         return false;
+      }
+      if (id != null)
+      {
+         return id.equals(((Association) that).id);
+      }
+      return super.equals(that);
+   }
+
+   @Override
+   public int hashCode()
+   {
+      if (id != null)
+      {
+         return id.hashCode();
+      }
+      return super.hashCode();
+   }
+}

--- a/javaee-impl/src/test/resources/org/jboss/forge/spec/jpa/EntityOnlyIdAndVersion.java
+++ b/javaee-impl/src/test/resources/org/jboss/forge/spec/jpa/EntityOnlyIdAndVersion.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+import javax.persistence.Entity;
+import java.io.Serializable;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Column;
+import javax.persistence.Version;
+import java.lang.Override;
+
+@Entity
+public class EntityOnlyIdAndVersion implements Serializable
+{
+
+   @Id
+   @GeneratedValue(strategy = GenerationType.AUTO)
+   @Column(name = "id", updatable = false, nullable = false)
+   private Long id = null;
+   
+   @Version
+   private @Column(name = "version")
+   int version = 0;
+   
+   public Long getId()
+   {
+      return this.id;
+   }
+
+   public void setId(final Long id)
+   {
+      this.id = id;
+   }
+
+   public int getVersion()
+   {
+      return this.version;
+   }
+
+   public void setVersion(final int version)
+   {
+      this.version = version;
+   }
+   
+   public String toString()
+   {
+      String result = "";
+      if (id != null)
+         result += id;
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object that)
+   {
+      if (this == that)
+      {
+         return true;
+      }
+      if (that == null)
+      {
+         return false;
+      }
+      if (getClass() != that.getClass())
+      {
+         return false;
+      }
+      if (id != null)
+      {
+         return id.equals(((User) that).id);
+      }
+      return super.equals(that);
+   }
+
+   @Override
+   public int hashCode()
+   {
+      if (id != null)
+      {
+         return id.hashCode();
+      }
+      return super.hashCode();
+   }
+}

--- a/javaee-impl/src/test/resources/org/jboss/forge/spec/jpa/EntityWithBusinessKey.java
+++ b/javaee-impl/src/test/resources/org/jboss/forge/spec/jpa/EntityWithBusinessKey.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+import javax.persistence.Entity;
+import java.io.Serializable;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Column;
+import javax.persistence.Version;
+import java.lang.Override;
+
+@Entity
+public class EntityWithBusinessKey implements Serializable
+{
+
+   @Id
+   @GeneratedValue(strategy = GenerationType.AUTO)
+   @Column(name = "id", updatable = false, nullable = false)
+   private Long id = null;
+   
+   @Version
+   private @Column(name = "version")
+   int version = 0;
+   
+   private String userName;
+
+   public Long getId()
+   {
+      return this.id;
+   }
+
+   public void setId(final Long id)
+   {
+      this.id = id;
+   }
+
+   public int getVersion()
+   {
+      return this.version;
+   }
+
+   public void setVersion(final int version)
+   {
+      this.version = version;
+   }
+   
+   public String getUserName()
+   {
+      return this.userName;
+   }
+
+   public void setUserName(final String userName)
+   {
+      this.userName = userName;
+   }
+
+   public String toString()
+   {
+      String result = "";
+      if (id != null)
+         result += id;
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object that)
+   {
+      if (this == that)
+      {
+         return true;
+      }
+      if (that == null)
+      {
+         return false;
+      }
+      if (getClass() != that.getClass())
+      {
+         return false;
+      }
+      if (id != null)
+      {
+         return id.equals(((EntityWithBusinessKey) that).id);
+      }
+      return super.equals(that);
+   }
+
+   @Override
+   public int hashCode()
+   {
+      if (id != null)
+      {
+         return id.hashCode();
+      }
+      return super.hashCode();
+   }
+}

--- a/javaee-impl/src/test/resources/org/jboss/forge/spec/jpa/EntityWithCollection.java
+++ b/javaee-impl/src/test/resources/org/jboss/forge/spec/jpa/EntityWithCollection.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+import javax.persistence.Entity;
+import java.io.Serializable;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Column;
+import javax.persistence.Version;
+import java.lang.Override;
+import java.util.List;
+
+@Entity
+public class EntityWithCollection implements Serializable
+{
+
+   @Id
+   @GeneratedValue(strategy = GenerationType.AUTO)
+   @Column(name = "id", updatable = false, nullable = false)
+   private Long id = null;
+   
+   @Version
+   private @Column(name = "version")
+   int version = 0;
+   
+   @OneToMany
+   private List<Association> associations = new ArrayList<Association>();
+
+   public Long getId()
+   {
+      return this.id;
+   }
+
+   public void setId(final Long id)
+   {
+      this.id = id;
+   }
+
+   public int getVersion()
+   {
+      return this.version;
+   }
+
+   public void setVersion(final int version)
+   {
+      this.version = version;
+   }
+   
+   public List<Association> getAddresses()
+   {
+      return this.associations;
+   }
+
+   public void setAddresses(final List<Association> associations)
+   {
+      this.associations = associations;
+   }
+
+   public String toString()
+   {
+      String result = "";
+      if (id != null)
+         result += id;
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object that)
+   {
+      if (this == that)
+      {
+         return true;
+      }
+      if (that == null)
+      {
+         return false;
+      }
+      if (getClass() != that.getClass())
+      {
+         return false;
+      }
+      if (id != null)
+      {
+         return id.equals(((EntityWithCollection) that).id);
+      }
+      return super.equals(that);
+   }
+
+   @Override
+   public int hashCode()
+   {
+      if (id != null)
+      {
+         return id.hashCode();
+      }
+      return super.hashCode();
+   }
+}

--- a/javaee-impl/src/test/resources/org/jboss/forge/spec/jpa/EntityWithMultipleFields.java
+++ b/javaee-impl/src/test/resources/org/jboss/forge/spec/jpa/EntityWithMultipleFields.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+import javax.persistence.Entity;
+import java.io.Serializable;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Column;
+import javax.persistence.Transient;
+import javax.persistence.Version;
+import java.lang.Override;
+import java.util.List;
+
+@Entity
+public class EntityWithMultipleFields implements Serializable
+{
+
+   @Id
+   @GeneratedValue(strategy = GenerationType.AUTO)
+   @Column(name = "id", updatable = false, nullable = false)
+   private Long id = null;
+   
+   @Version
+   private @Column(name = "version")
+   int version = 0;
+   
+   @OneToMany
+   private List<Association> associations = new ArrayList<Association>();
+   
+   private String firstName;
+   
+   private String lastName;
+   
+   @Transient
+   private String fullName;
+
+   public Long getId()
+   {
+      return this.id;
+   }
+
+   public void setId(final Long id)
+   {
+      this.id = id;
+   }
+
+   public int getVersion()
+   {
+      return this.version;
+   }
+
+   public void setVersion(final int version)
+   {
+      this.version = version;
+   }
+   
+   public List<Association> getAddresses()
+   {
+      return this.associations;
+   }
+
+   public void setAddresses(final List<Association> associations)
+   {
+      this.associations = associations;
+   }
+   
+   public String getFirstName()
+   {
+      return this.firstName;
+   }
+
+   public void setFirstName(final String firstName)
+   {
+      this.firstName = firstName;
+   }
+
+   public String getLastName()
+   {
+      return this.lastName;
+   }
+
+   public void setLastName(final String lastName)
+   {
+      this.lastName = lastName;
+   }
+   
+   public String getFullName()
+   {
+      return this.firstName + " " + this.lastName;
+   }
+
+   public String toString()
+   {
+      String result = "";
+      if (id != null)
+         result += id;
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object that)
+   {
+      if (this == that)
+      {
+         return true;
+      }
+      if (that == null)
+      {
+         return false;
+      }
+      if (getClass() != that.getClass())
+      {
+         return false;
+      }
+      if (id != null)
+      {
+         return id.equals(((EntityWithMultipleFields) that).id);
+      }
+      return super.equals(that);
+   }
+
+   @Override
+   public int hashCode()
+   {
+      if (id != null)
+      {
+         return id.hashCode();
+      }
+      return super.hashCode();
+   }
+}

--- a/javaee-impl/src/test/resources/org/jboss/forge/spec/jpa/EntityWithTransientField.java
+++ b/javaee-impl/src/test/resources/org/jboss/forge/spec/jpa/EntityWithTransientField.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+import javax.persistence.Entity;
+import javax.persistence.Transient;
+import java.io.Serializable;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Column;
+import javax.persistence.Version;
+import java.lang.Override;
+
+@Entity
+public class EntityWithTransientField implements Serializable
+{
+
+   @Id
+   @GeneratedValue(strategy = GenerationType.AUTO)
+   @Column(name = "id", updatable = false, nullable = false)
+   private Long id = null;
+   
+   @Version
+   private @Column(name = "version")
+   int version = 0;
+   
+   private String firstName;
+   
+   private String lastName;
+   
+   @Transient
+   private String fullName;
+
+   public Long getId()
+   {
+      return this.id;
+   }
+
+   public void setId(final Long id)
+   {
+      this.id = id;
+   }
+
+   public int getVersion()
+   {
+      return this.version;
+   }
+
+   public void setVersion(final int version)
+   {
+      this.version = version;
+   }
+   
+   public String getFirstName()
+   {
+      return this.firstName;
+   }
+
+   public void setFirstName(final String firstName)
+   {
+      this.firstName = firstName;
+   }
+
+   public String getLastName()
+   {
+      return this.lastName;
+   }
+
+   public void setLastName(final String lastName)
+   {
+      this.lastName = lastName;
+   }
+   
+   public String getFullName()
+   {
+      return this.firstName + " " + this.lastName;
+   }
+
+   public String toString()
+   {
+      String result = "";
+      if (id != null)
+         result += id;
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object that)
+   {
+      if (this == that)
+      {
+         return true;
+      }
+      if (that == null)
+      {
+         return false;
+      }
+      if (getClass() != that.getClass())
+      {
+         return false;
+      }
+      if (id != null)
+      {
+         return id.equals(((EntityWithTransientField) that).id);
+      }
+      return super.equals(that);
+   }
+
+   @Override
+   public int hashCode()
+   {
+      if (id != null)
+      {
+         return id.hashCode();
+      }
+      return super.hashCode();
+   }
+}


### PR DESCRIPTION
Removed the creation of equals and hashCode from the entity plugin.

A new plugin 'update-entity' has been created to enable updating existing JPA entities with equals and hashCode implementations.
