### PR TITLE
FORGE-1017 Compute valid package name as default value in package prompt

### DIFF
--- a/shell-api/src/main/java/org/jboss/forge/shell/util/Packages.java
+++ b/shell-api/src/main/java/org/jboss/forge/shell/util/Packages.java
@@ -37,12 +37,29 @@ public class Packages
          throw new IllegalArgumentException("Package should not be null");
       }
       StringBuilder sb = new StringBuilder(pkg.length());
+      boolean hasIdentifierStarted = false; 
       for (int i = 0; i < pkg.length(); i++)
       {
-         char c = pkg.charAt(i);
-         if (c == '.' || Character.isJavaIdentifierPart(c))
+         int c = pkg.codePointAt(i);
+         if(!hasIdentifierStarted)
          {
-            sb.append(c);
+            if(Character.isJavaIdentifierStart(c))
+            {
+               sb.appendCodePoint(c);
+               hasIdentifierStarted = true;
+            }
+         }
+         else
+         {
+            if (Character.isJavaIdentifierPart(c))
+            {
+               sb.appendCodePoint(c);
+            }
+            else if(c == '.')
+            {
+               sb.appendCodePoint(c);
+               hasIdentifierStarted = false;
+            }
          }
       }
       return sb.toString();

--- a/shell-api/src/test/java/org/jboss/forge/shell/util/PackagesTest.java
+++ b/shell-api/src/test/java/org/jboss/forge/shell/util/PackagesTest.java
@@ -28,10 +28,17 @@ public class PackagesTest
    }
 
    @Test
-   public void testToInvalidPackage()
+   public void testInvalidPackage()
    {
       String pkg = "com.example.app-demo";
       Assert.assertEquals("com.example.appdemo", Packages.toValidPackageName(pkg));
+   }
+   
+   @Test
+   public void testAllInvalidPackage()
+   {
+      String pkg = ".-";
+      Assert.assertEquals("", Packages.toValidPackageName(pkg));
    }
 
 }

--- a/shell/src/main/java/org/jboss/forge/shell/command/ExecutionParser.java
+++ b/shell/src/main/java/org/jboss/forge/shell/command/ExecutionParser.java
@@ -35,6 +35,7 @@ import org.jboss.forge.shell.exceptions.PluginExecutionException;
 import org.jboss.forge.shell.plugins.PipeOut;
 import org.jboss.forge.shell.util.Enums;
 import org.jboss.forge.shell.util.GeneralUtils;
+import org.jboss.forge.shell.util.Packages;
 import org.mvel2.util.ParseTools;
 
 /**
@@ -222,7 +223,15 @@ public class ExecutionParser
             {
                // make sure the current option value is OK
                ShellMessages.info(shell, "Could not parse [" + value + "]... please try again...");
-               value = shell.promptCommon(optionDescriptor, promptType);
+               if (promptType.equals(PromptType.JAVA_PACKAGE))
+               {
+                  String defaultPackage = value == null ? "" : Packages.toValidPackageName((String) value);
+                  value = shell.promptCommon(optionDescriptor, promptType, defaultPackage);
+               }
+               else
+               {
+                  value = shell.promptCommon(optionDescriptor, promptType);
+               }
             }
             else if (option.isRequired() && (value == null) && (!option.hasDefaultValue()))
             {


### PR DESCRIPTION
Also corrected the logic by vieryfing if the package name starts with a valid Java identifier codepoint.
This does not verify if keywords are used in the original string and nor does it remove them.
