### PR TITLE
FORGE-44 Increase intensity of colors for Windows consoles.

### DIFF
--- a/shell/src/main/java/org/jboss/forge/shell/ShellImpl.java
+++ b/shell/src/main/java/org/jboss/forge/shell/ShellImpl.java
@@ -1015,6 +1015,12 @@ public class ShellImpl extends AbstractShellPrompt implements Shell
       }
 
       Ansi ansi = new Ansi();
+      
+      // Handle the darker Window consoles by increasing intensity
+      if(OSUtils.isWindows() && !environment.isEmbedded())
+      {
+         ansi.a(Ansi.Attribute.INTENSITY_BOLD);
+      }
 
       switch (color)
       {


### PR DESCRIPTION
Set the intensity to bold if a non-embedded Windows Forge environment is detected. This is quite similar to the Spring Roo fix in ROO-350, except that I decided to use Jansi to change the brightness through Jansi.
