### PR TITLE
FORGE-1100 Use the in-flight project instance for configuration

### DIFF
--- a/shell-api/src/main/java/org/jboss/forge/project/services/ProjectFactory.java
+++ b/shell-api/src/main/java/org/jboss/forge/project/services/ProjectFactory.java
@@ -37,6 +37,7 @@ public class ProjectFactory
    private List<ProjectLocator> locators;
    private final BeanManager manager;
    private final Instance<ProjectLocator> locatorInstance;
+   private Project transientProject;
 
    @Inject
    public ProjectFactory(final FacetFactory facetFactory, final BeanManager manager,
@@ -114,7 +115,9 @@ public class ProjectFactory
 
       if (project != null)
       {
+         setTransientProject(project);
          registerFacets(project);
+         setTransientProject(null);
       }
 
       return project;
@@ -143,7 +146,9 @@ public class ProjectFactory
             installSingleFacet(project, type);
          }
 
+         setTransientProject(project);
          registerFacets(project);
+         setTransientProject(null);
       }
       return project;
    }
@@ -234,7 +239,9 @@ public class ProjectFactory
 
          if (project != null)
          {
+            setTransientProject(project);
             registerFacets(project);
+            setTransientProject(null);
          }
       }
       return project;
@@ -244,5 +251,15 @@ public class ProjectFactory
    {
       init();
       return locators;
+   }
+
+   public Project getTransientProject()
+   {
+      return transientProject;
+   }
+
+   private void setTransientProject(Project project)
+   {
+      this.transientProject = project;
    }
 }


### PR DESCRIPTION
The in-flight project instance that is being setup will now be
used whenever Facets are being registered. The underlying
configuration file of this project instance will be used when
requested.

This will ensure that @Inject 'ed Configuration instances can
be used inside Facet.install() and Facet.isInstalled() methods.
These injected Configuration instances will no longer use the
User scoped configuration store if there is a project
associated with the facet.
