### PR TITLE
FORGE-1427 Delay expansion of command line args in Windows.

### DIFF
--- a/dist/src/main/resources/bin/forge.bat
+++ b/dist/src/main/resources/bin/forge.bat
@@ -111,6 +111,7 @@ goto error
 
 @REM Initializing the argument line and the plugin directory if any
 :init
+setlocal enableextensions enabledelayedexpansion
 set FORGE_CMD_LINE_ARGS=
 set FORGE_DEBUG_ARGS=
 


### PR DESCRIPTION
This ensures that replacement of commas and semicolons will be done, thus bypassing any manipulation of arguments passed to the script by CMD.
