### PR TITLE
FORGE-1443 database.action property is drop-and-create

### DIFF
--- a/javaee/api/src/main/java/org/jboss/forge/addon/javaee/jpa/PersistenceProvider.java
+++ b/javaee/api/src/main/java/org/jboss/forge/addon/javaee/jpa/PersistenceProvider.java
@@ -9,6 +9,7 @@ package org.jboss.forge.addon.javaee.jpa;
 import java.util.List;
 
 import org.jboss.forge.addon.dependencies.Dependency;
+import org.jboss.forge.addon.projects.Project;
 import org.jboss.shrinkwrap.descriptor.api.persistence.PersistenceUnitCommon;
 
 /**
@@ -31,10 +32,11 @@ public interface PersistenceProvider
    String getProvider();
 
    /**
-    * Configure the {@link PersistenceUnitDef} and {@link JPADataSource}.
+    * Configure the {@link PersistenceUnitCommon} and {@link JPADataSource}.
     */
    @SuppressWarnings("rawtypes")
-   PersistenceUnitCommon configure(PersistenceUnitCommon unit, JPADataSource ds);
+   PersistenceUnitCommon configure(PersistenceUnitCommon unit, JPADataSource ds,
+            Project project);
 
    /**
     * List any dependencies required by this provider.

--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/PersistenceOperations.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/PersistenceOperations.java
@@ -76,7 +76,7 @@ public class PersistenceOperations
          }
 
          container.setupConnection(unit, dataSource);
-         provider.configure(unit, dataSource);
+         provider.configure(unit, dataSource, project);
          facet.saveConfig(config);
          result = facet.getConfigFile();
          if (configureMetadata)

--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/providers/EclipseLinkProvider.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/providers/EclipseLinkProvider.java
@@ -17,6 +17,7 @@ import org.jboss.forge.addon.javaee.jpa.DatabaseType;
 import org.jboss.forge.addon.javaee.jpa.JPADataSource;
 import org.jboss.forge.addon.javaee.jpa.MetaModelProvider;
 import org.jboss.forge.addon.javaee.jpa.PersistenceProvider;
+import org.jboss.forge.addon.projects.Project;
 import org.jboss.shrinkwrap.descriptor.api.persistence.PersistenceUnitCommon;
 import org.jboss.shrinkwrap.descriptor.api.persistence.PropertiesCommon;
 
@@ -75,7 +76,7 @@ public class EclipseLinkProvider implements PersistenceProvider
 
    @SuppressWarnings("rawtypes")
    @Override
-   public PersistenceUnitCommon configure(PersistenceUnitCommon unit, JPADataSource ds)
+   public PersistenceUnitCommon configure(PersistenceUnitCommon unit, JPADataSource ds, Project project)
    {
       unit.excludeUnlistedClasses(Boolean.FALSE);
       PropertiesCommon properties = unit.getOrCreateProperties();

--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/providers/HibernateProvider.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/providers/HibernateProvider.java
@@ -17,6 +17,7 @@ import org.jboss.forge.addon.javaee.jpa.DatabaseType;
 import org.jboss.forge.addon.javaee.jpa.JPADataSource;
 import org.jboss.forge.addon.javaee.jpa.MetaModelProvider;
 import org.jboss.forge.addon.javaee.jpa.PersistenceProvider;
+import org.jboss.forge.addon.projects.Project;
 import org.jboss.shrinkwrap.descriptor.api.persistence.PersistenceUnitCommon;
 import org.jboss.shrinkwrap.descriptor.api.persistence.PropertiesCommon;
 
@@ -65,7 +66,7 @@ public class HibernateProvider implements PersistenceProvider
 
    @Override
    @SuppressWarnings("rawtypes")
-   public PersistenceUnitCommon configure(PersistenceUnitCommon unit, JPADataSource ds)
+   public PersistenceUnitCommon configure(PersistenceUnitCommon unit, JPADataSource ds, Project project)
    {
       unit.excludeUnlistedClasses(Boolean.FALSE);
       PropertiesCommon properties = unit.getOrCreateProperties();

--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/providers/InfinispanProvider.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/providers/InfinispanProvider.java
@@ -14,6 +14,7 @@ import org.jboss.forge.addon.dependencies.builder.DependencyBuilder;
 import org.jboss.forge.addon.javaee.jpa.JPADataSource;
 import org.jboss.forge.addon.javaee.jpa.MetaModelProvider;
 import org.jboss.forge.addon.javaee.jpa.PersistenceProvider;
+import org.jboss.forge.addon.projects.Project;
 import org.jboss.shrinkwrap.descriptor.api.persistence.PersistenceUnitCommon;
 import org.jboss.shrinkwrap.descriptor.api.persistence.PropertyCommon;
 
@@ -27,7 +28,7 @@ public class InfinispanProvider implements PersistenceProvider
 
    @Override
    @SuppressWarnings("rawtypes")
-   public PersistenceUnitCommon configure(PersistenceUnitCommon unit, JPADataSource ds)
+   public PersistenceUnitCommon configure(PersistenceUnitCommon unit, JPADataSource ds, Project project)
    {
       unit.excludeUnlistedClasses(Boolean.FALSE);
       PropertyCommon dialectProperty = unit.getOrCreateProperties().createProperty();

--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/providers/JavaEEDefaultProvider.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/providers/JavaEEDefaultProvider.java
@@ -14,6 +14,8 @@ import org.jboss.forge.addon.dependencies.Dependency;
 import org.jboss.forge.addon.javaee.jpa.JPADataSource;
 import org.jboss.forge.addon.javaee.jpa.MetaModelProvider;
 import org.jboss.forge.addon.javaee.jpa.PersistenceProvider;
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.projects.facets.MetadataFacet;
 import org.jboss.forge.furnace.versions.SingleVersion;
 import org.jboss.shrinkwrap.descriptor.api.persistence.PersistenceCommonDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.persistence.PersistenceUnitCommon;
@@ -40,16 +42,27 @@ public class JavaEEDefaultProvider implements PersistenceProvider
 
    @Override
    @SuppressWarnings("rawtypes")
-   public PersistenceUnitCommon configure(PersistenceUnitCommon unit, JPADataSource ds)
+   public PersistenceUnitCommon configure(PersistenceUnitCommon unit, JPADataSource ds, Project project)
    {
       unit.excludeUnlistedClasses(Boolean.FALSE);
       PersistenceCommonDescriptor descriptor = (PersistenceCommonDescriptor) unit.up();
       if (new SingleVersion(descriptor.getVersion()).compareTo(new SingleVersion("2.1")) >= 0)
       {
          PropertiesCommon properties = unit.getOrCreateProperties();
-         properties.createProperty().name("javax.persistence.schema-generation.database.action").value("create");
+         properties.createProperty().name("javax.persistence.schema-generation.database.action").value("drop-and-create");
+         properties.createProperty().name("javax.persistence.schema-generation.scripts.action").value("drop-and-create");
+         String createDdlFileName = project == null ? "create.ddl" : getProjectName(project) + "Create.ddl";
+         properties.createProperty().name("javax.persistence.schema-generation.scripts.create-target").value(createDdlFileName);
+         String dropDdlFileName = project == null ? "drop.ddl" : getProjectName(project) + "Drop.ddl";
+         properties.createProperty().name("javax.persistence.schema-generation.scripts.drop-target").value(dropDdlFileName);
       }
       return unit;
+   }
+
+   private String getProjectName(Project project)
+   {
+      MetadataFacet metadata = project.getFacet(MetadataFacet.class);
+      return metadata.getProjectName();
    }
 
    @Override

--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/providers/OpenJPAProvider.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/providers/OpenJPAProvider.java
@@ -17,6 +17,7 @@ import org.jboss.forge.addon.javaee.jpa.DatabaseType;
 import org.jboss.forge.addon.javaee.jpa.JPADataSource;
 import org.jboss.forge.addon.javaee.jpa.MetaModelProvider;
 import org.jboss.forge.addon.javaee.jpa.PersistenceProvider;
+import org.jboss.forge.addon.projects.Project;
 import org.jboss.shrinkwrap.descriptor.api.persistence.PersistenceUnitCommon;
 import org.jboss.shrinkwrap.descriptor.api.persistence.PropertyCommon;
 
@@ -64,7 +65,7 @@ public class OpenJPAProvider implements PersistenceProvider
 
    @Override
    @SuppressWarnings("rawtypes")
-   public PersistenceUnitCommon configure(PersistenceUnitCommon unit, JPADataSource ds)
+   public PersistenceUnitCommon configure(PersistenceUnitCommon unit, JPADataSource ds, Project project)
    {
       unit.excludeUnlistedClasses(Boolean.FALSE);
 


### PR DESCRIPTION
The default Java EE persistence provider is based on JPA 2.1, where you
have all those standard properties that should be supported by all
providers. So Forge sets one of those properties (database.action) to
drop-and-create. It also adds some DDL schema generation properties.
