### PR TITLE
Ported Maven Profile API to Forge 2.

### DIFF
--- a/maven/api/src/main/java/org/jboss/forge/addon/maven/profiles/Profile.java
+++ b/maven/api/src/main/java/org/jboss/forge/addon/maven/profiles/Profile.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.addon.maven.profiles;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.jboss.forge.addon.dependencies.Dependency;
+import org.jboss.forge.addon.dependencies.DependencyRepository;
+
+public interface Profile
+{
+    String getId();
+
+    boolean isActiveByDefault();
+
+    List<Dependency> listDependencies();
+
+    List<DependencyRepository> listRepositories();
+
+    Properties getProperties();
+}

--- a/maven/impl/src/main/java/org/jboss/forge/addon/maven/profiles/ProfileAdapter.java
+++ b/maven/impl/src/main/java/org/jboss/forge/addon/maven/profiles/ProfileAdapter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.addon.maven.profiles;
+
+import org.apache.maven.model.Activation;
+import org.apache.maven.model.Repository;
+import org.jboss.forge.addon.maven.dependencies.MavenDependencyAdapter;
+import org.jboss.forge.addon.dependencies.Dependency;
+import org.jboss.forge.addon.dependencies.DependencyRepository;
+
+public class ProfileAdapter extends org.apache.maven.model.Profile
+{
+    private static final long serialVersionUID = 4863517832291256970L;
+
+    public ProfileAdapter(final Profile profile)
+    {
+        setId(profile.getId());
+        Activation activation = new Activation();
+        activation.setActiveByDefault(profile.isActiveByDefault());
+
+        setActivation(activation);
+
+        for (Dependency dependency : profile.listDependencies())
+        {
+            getDependencies().add(new MavenDependencyAdapter(dependency));
+        }
+
+        for (DependencyRepository repository : profile.listRepositories())
+        {
+            Repository mavenRepository = new Repository();
+            mavenRepository.setId(repository.getId());
+            mavenRepository.setUrl(repository.getUrl());
+            getRepositories().add(mavenRepository);
+        }
+
+        setProperties(profile.getProperties());
+    }
+}

--- a/maven/impl/src/main/java/org/jboss/forge/addon/maven/profiles/ProfileBuilder.java
+++ b/maven/impl/src/main/java/org/jboss/forge/addon/maven/profiles/ProfileBuilder.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.addon.maven.profiles;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.jboss.forge.addon.dependencies.Dependency;
+import org.jboss.forge.addon.dependencies.DependencyRepository;
+
+public class ProfileBuilder implements Profile
+{
+    private ProfileImpl profile;
+
+    private ProfileBuilder(ProfileImpl profile)
+    {
+        this.profile = profile;
+    }
+
+    public static ProfileBuilder create()
+    {
+        return new ProfileBuilder(new ProfileImpl());
+    }
+
+    public static ProfileBuilder create(Profile profile)
+    {
+        if (profile instanceof ProfileImpl)
+        {
+            return new ProfileBuilder((ProfileImpl) profile);
+        } else if (profile instanceof ProfileBuilder)
+        {
+            return new ProfileBuilder(((ProfileBuilder) profile).profile);
+        }
+
+        throw new IllegalArgumentException("Profile of type '" + profile.getClass().getName() + "' is not supported");
+    }
+
+    @Override public String getId()
+    {
+        return profile.getId();
+    }
+
+    @Override public boolean isActiveByDefault()
+    {
+        return profile.isActiveByDefault();
+    }
+
+    @Override public List<Dependency> listDependencies()
+    {
+        return profile.listDependencies();
+    }
+
+    @Override public List<DependencyRepository> listRepositories()
+    {
+        return profile.listRepositories();
+    }
+
+    @Override public Properties getProperties()
+    {
+        return profile.getProperties();
+    }
+
+    public ProfileBuilder setId(String id)
+    {
+        profile.setId(id);
+        return this;
+    }
+
+    public ProfileBuilder setActiveByDefault(boolean activeByDefault)
+    {
+        profile.setActivateByDefault(activeByDefault);
+        return this;
+    }
+
+    public ProfileBuilder addDependency(Dependency dependency)
+    {
+        profile.listDependencies().add(dependency);
+        return this;
+    }
+
+    public ProfileBuilder addRepository(DependencyRepository repository)
+    {
+        profile.listRepositories().add(repository);
+        return this;
+    }
+
+    public ProfileBuilder addProperty(String key, String value)
+    {
+        profile.getProperties().setProperty(key, value);
+        return this;
+    }
+
+    public org.apache.maven.model.Profile getAsMavenProfile()
+    {
+        return new ProfileAdapter(profile);
+    }
+}

--- a/maven/impl/src/main/java/org/jboss/forge/addon/maven/profiles/ProfileImpl.java
+++ b/maven/impl/src/main/java/org/jboss/forge/addon/maven/profiles/ProfileImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.addon.maven.profiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.jboss.forge.addon.dependencies.Dependency;
+import org.jboss.forge.addon.dependencies.DependencyRepository;
+
+public class ProfileImpl implements Profile
+{
+    private String id;
+    private boolean activateByDefault;
+    private List<Dependency> dependencies = new ArrayList<Dependency>();
+    private List<DependencyRepository> repositories = new ArrayList<DependencyRepository>();
+    private Properties properties = new Properties();
+
+    @Override public String getId()
+    {
+        return id;
+    }
+
+    @Override public boolean isActiveByDefault()
+    {
+        return activateByDefault;
+    }
+
+    @Override public List<Dependency> listDependencies()
+    {
+        return dependencies;
+    }
+
+    @Override public List<DependencyRepository> listRepositories()
+    {
+        return repositories;
+    }
+
+    @Override public Properties getProperties()
+    {
+        return properties;
+    }
+
+    public void setId(String id)
+    {
+        this.id = id;
+    }
+
+    public void setActivateByDefault(boolean activateByDefault)
+    {
+        this.activateByDefault = activateByDefault;
+    }
+}

--- a/maven/impl/src/test/java/org/jboss/forge/addon/maven/profiles/ProfileAdapterTest.java
+++ b/maven/impl/src/test/java/org/jboss/forge/addon/maven/profiles/ProfileAdapterTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.addon.maven.profiles;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.jboss.forge.addon.dependencies.builder.DependencyBuilder;
+import org.jboss.forge.addon.dependencies.DependencyRepository;
+import org.junit.Test;
+
+public class ProfileAdapterTest
+{
+    @Test
+    public void testCreateFromProfile()
+    {
+        ProfileBuilder profileBuilder =
+                ProfileBuilder.create()
+                        .setId("myid")
+                        .setActiveByDefault(true)
+                        .addDependency(DependencyBuilder.create("mygroupId:myartifactId"))
+                        .addDependency(DependencyBuilder.create("mygroupId:mysecond"))
+                        .addRepository(new DependencyRepository("id", "url"));
+
+        ProfileAdapter profileAdapter = new ProfileAdapter(profileBuilder);
+        assertThat(profileAdapter.getId(), is(profileBuilder.getId()));
+        assertThat(profileAdapter.getActivation().isActiveByDefault(), is(true));
+        assertThat(profileAdapter.getDependencies().size(), is(2));
+        assertThat(profileAdapter.getRepositories().size(), is(1));
+    }
+}

--- a/maven/impl/src/test/java/org/jboss/forge/addon/maven/profiles/ProfileBuilderTest.java
+++ b/maven/impl/src/test/java/org/jboss/forge/addon/maven/profiles/ProfileBuilderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.addon.maven.profiles;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.maven.model.Profile;
+import org.jboss.forge.addon.dependencies.builder.DependencyBuilder;
+import org.jboss.forge.addon.dependencies.DependencyRepository;
+import org.junit.Test;
+
+public class ProfileBuilderTest
+{
+    @Test
+    public void testCreateWithExistingProfile() throws Exception
+    {
+        ProfileImpl profile = new ProfileImpl();
+        profile.setId("testprofile");
+
+        ProfileBuilder profileBuilder = ProfileBuilder.create(profile);
+        assertThat(profileBuilder.getId(), is(profile.getId()));
+    }
+
+    @Test
+    public void testCreate()
+    {
+        ProfileBuilder profileBuilder = ProfileBuilder.create();
+        assertNotNull(profileBuilder);
+    }
+
+    @Test
+    public void testMethodChaining()
+    {
+        ProfileBuilder profileBuilder =
+                ProfileBuilder.create()
+                        .setId("myid")
+                        .setActiveByDefault(true)
+                        .addDependency(DependencyBuilder.create("mygroupId:myartifactId"))
+                        .addRepository(new DependencyRepository("id", "url"));
+
+        assertTrue(profileBuilder.isActiveByDefault());
+    }
+
+    @Test
+    public void testAsMavenProfile()
+    {
+        ProfileBuilder profileBuilder =
+                ProfileBuilder.create()
+                        .setId("myid")
+                        .setActiveByDefault(true)
+                        .addDependency(DependencyBuilder.create("mygroupId:myartifactId"))
+                        .addRepository(new DependencyRepository("id", "url"));
+        Profile mavenProfile = profileBuilder.getAsMavenProfile();
+        assertThat(mavenProfile.getId(), is(profileBuilder.getId()));
+    }
+
+    @Test
+    public void testAddProperty()
+    {
+        ProfileBuilder profileBuilder =
+                ProfileBuilder.create()
+                        .addProperty("prop1", "val1")
+                        .addProperty("prop2", "val2")
+                        .addProperty("prop3", "prop3");
+
+        Profile mavenProfile = profileBuilder.getAsMavenProfile();
+        assertThat(mavenProfile.getProperties().size(), is(3));
+    }
+}


### PR DESCRIPTION
This is a port of the Maven Profile API from Forge 1.

I needed this API to port the Web-Test-Harness from Forge 1 where an Arquillian profile needed to added to the Maven project POM.
