### PR TITLE
FORGE-1625 Adding UIWIzard to NavigationResultEntry is disallowed.

### DIFF
--- a/ui/api/src/main/java/org/jboss/forge/addon/ui/result/navigation/NavigationResultBuilder.java
+++ b/ui/api/src/main/java/org/jboss/forge/addon/ui/result/navigation/NavigationResultBuilder.java
@@ -16,6 +16,7 @@ import org.jboss.forge.addon.ui.command.UICommand;
 import org.jboss.forge.addon.ui.metadata.UICommandMetadata;
 import org.jboss.forge.addon.ui.result.NavigationResult;
 import org.jboss.forge.addon.ui.result.NavigationResultEntry;
+import org.jboss.forge.addon.ui.wizard.UIWizard;
 
 /**
  * Builds a {@link NavigationResult} object
@@ -30,11 +31,23 @@ public final class NavigationResultBuilder
    {
    }
 
+   /**
+    * Create a new instance of a NavigationResultBuilder
+    * 
+    * @return A NavigationResultBuilder instance
+    */
    public static NavigationResultBuilder create()
    {
       return new NavigationResultBuilder();
    }
 
+   /**
+    * Create a new instance of a NavigationResultBuilder using the provided NavigationResult instance as a base.
+    * 
+    * @param result A NavigationResult whose entries are used as the basis to eventually construct a new
+    *           NavigationResult through this NavigationResultBuilder.
+    * @return A NavigationResultBuilder instance
+    */
    public static NavigationResultBuilder create(NavigationResult result)
    {
       NavigationResultBuilder builder = new NavigationResultBuilder();
@@ -45,29 +58,65 @@ public final class NavigationResultBuilder
       return builder;
    }
 
+   /**
+    * Add a UICommand type to create a single navigation entry.
+    * 
+    * @param type The UICommand type to add
+    * @return This NavigationResultBuilder instance
+    */
    public NavigationResultBuilder add(Class<? extends UICommand> type)
    {
       entries.add(new ClassNavigationResultEntry(type));
       return this;
    }
 
+   /**
+    * Add a UICommand instance to create a single navigation entry.
+    * 
+    * @param command The UICommand to add
+    * @return This NavigationResultBuilder instance
+    */
    public NavigationResultBuilder add(UICommand command)
    {
       entries.add(new CommandNavigationResultEntry(command));
       return this;
    }
 
+   /**
+    * Add multiple UICommand types to create a single navigation entry. Every invocation of this method creates a
+    * separate navigation entry. UIWizard types must not be provided as arguments since wizards and wizard steps cannot
+    * be combined with other UICommand types in the same navigation entry.
+    * 
+    * Use the other add(...) methods to add UIWizard types.
+    * 
+    * @param metadata The command metadata
+    * @param types The UICommand types to add as a single navigation entry
+    * @return This NavigationResultBuilder instance
+    */
    public NavigationResultBuilder add(UICommandMetadata metadata, Iterable<Class<? extends UICommand>> types)
    {
       List<NavigationResultEntry> internalEntries = new ArrayList<>();
       for (Class<? extends UICommand> type : types)
       {
-         internalEntries.add(new ClassNavigationResultEntry(type));
+         if (UIWizard.class.isAssignableFrom(type))
+         {
+            throw new IllegalArgumentException("A UICommand of type " + type + " was added. "
+                     + UIWizard.class.getSimpleName() + " instances should be added individually.");
+         }
+         else
+         {
+            internalEntries.add(new ClassNavigationResultEntry(type));
+         }
       }
       entries.add(new CompositeNavigationResultEntry(metadata, internalEntries));
       return this;
    }
 
+   /**
+    * Create a NavigationResult instance representing the entries that have been added.
+    * 
+    * @return A NavigationResult instance
+    */
    public NavigationResult build()
    {
       if (entries.isEmpty())

--- a/ui/api/src/test/java/org/jboss/forge/addon/ui/result/navigation/NavigationResultBuilderTest.java
+++ b/ui/api/src/test/java/org/jboss/forge/addon/ui/result/navigation/NavigationResultBuilderTest.java
@@ -7,13 +7,16 @@
 
 package org.jboss.forge.addon.ui.result.navigation;
 
+import org.jboss.forge.addon.ui.command.UICommand;
 import org.jboss.forge.addon.ui.result.NavigationResult;
 import org.jboss.forge.addon.ui.result.navigation.NavigationResultBuilder;
-import org.jboss.forge.addon.ui.util.MockCommand;
-import org.jboss.forge.addon.ui.util.MockCommand2;
-import org.jboss.forge.addon.ui.util.MockCommand3;
+import org.jboss.forge.addon.ui.util.*;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Tests for {@link NavigationResultBuilder}
@@ -67,4 +70,13 @@ public class NavigationResultBuilderTest
       Assert.assertNotNull(result.getNext());
       Assert.assertEquals(4, result.getNext().length);
    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilderAddWithWizardArgument()
+    {
+        NavigationResultBuilder builder = NavigationResultBuilder.create();
+        List<Class<? extends UICommand>> commands = new ArrayList<>();
+        commands.add(MockWizard.class);
+        builder.add(Metadata.forCommand(MockWizard.class), commands);
+    }
 }

--- a/ui/api/src/test/java/org/jboss/forge/addon/ui/util/MockWizard.java
+++ b/ui/api/src/test/java/org/jboss/forge/addon/ui/util/MockWizard.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.addon.ui.util;
+
+import org.jboss.forge.addon.ui.command.UICommand;
+import org.jboss.forge.addon.ui.context.*;
+import org.jboss.forge.addon.ui.metadata.UICommandMetadata;
+import org.jboss.forge.addon.ui.result.NavigationResult;
+import org.jboss.forge.addon.ui.result.Result;
+import org.jboss.forge.addon.ui.wizard.UIWizard;
+
+/**
+ * @author Vineet Reynolds
+ */
+public class MockWizard implements UIWizard
+{
+
+   @Override
+   public NavigationResult next(UINavigationContext context) throws Exception
+   {
+      return null;
+   }
+
+   @Override
+   public UICommandMetadata getMetadata(UIContext context)
+   {
+      return Metadata.forCommand(MockWizard.class);
+   }
+
+   @Override
+   public boolean isEnabled(UIContext context)
+   {
+      return false;
+   }
+
+   @Override
+   public void initializeUI(UIBuilder builder) throws Exception
+   {
+
+   }
+
+   @Override
+   public void validate(UIValidationContext context)
+   {
+
+   }
+
+   @Override
+   public Result execute(UIExecutionContext context) throws Exception
+   {
+      return null;
+   }
+}


### PR DESCRIPTION
An IllegalArgumentException is thrown when it is detected that a UIWizard instance is present in the list of arguments when creating a NavigationResultEntry.
