### PR TITLE
FORGE-1628 Add TemplateFacet and a MavenTemplateFacet.

### DIFF
--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/facets/MavenTemplateFacet.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/facets/MavenTemplateFacet.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.addon.maven.projects.facets;
+
+import java.io.File;
+
+import javax.enterprise.context.Dependent;
+
+import org.jboss.forge.addon.facets.AbstractFacet;
+import org.jboss.forge.addon.facets.constraints.FacetConstraint;
+import org.jboss.forge.addon.maven.projects.MavenFacet;
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.projects.facets.TemplateFacet;
+import org.jboss.forge.addon.resource.DirectoryResource;
+import org.jboss.forge.addon.resource.FileResource;
+
+/**
+ * An implementation of the {@link org.jboss.forge.addon.projects.facets.TemplateFacet} for Maven projects.
+ * 
+ * @author Vineet Reynolds
+ */
+@Dependent
+@FacetConstraint(MavenFacet.class)
+public class MavenTemplateFacet extends AbstractFacet<Project> implements TemplateFacet
+{
+
+   @Override
+   public DirectoryResource getRootTemplateDirectory()
+   {
+      Project project = getFaceted();
+      return project.getRootDirectory().getChildDirectory("src" + File.separator + "main"
+               + File.separator + "templates");
+   }
+
+   @Override
+   public DirectoryResource getTemplateDirectory(String provider)
+   {
+      return this.getRootTemplateDirectory().getChildDirectory(provider);
+   }
+
+   @Override
+   public boolean isInstalled()
+   {
+      Project project = getFaceted();
+      return project.hasFacet(MavenFacet.class) && getRootTemplateDirectory().exists();
+   }
+
+   @Override
+   public boolean install()
+   {
+      if (!this.isInstalled())
+      {
+         this.getRootTemplateDirectory().mkdir();
+      }
+      return true;
+   }
+
+   @Override
+   public FileResource<?> getResource(final String provider, final String relativePath)
+   {
+      return (FileResource<?>) getTemplateDirectory(provider).getChild(relativePath);
+   }
+
+}

--- a/projects/api/src/main/java/org/jboss/forge/addon/projects/facets/TemplateFacet.java
+++ b/projects/api/src/main/java/org/jboss/forge/addon/projects/facets/TemplateFacet.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.addon.projects.facets;
+
+import org.jboss.forge.addon.projects.ProjectFacet;
+import org.jboss.forge.addon.resource.DirectoryResource;
+import org.jboss.forge.addon.resource.FileResource;
+
+/**
+ * A Facet for template resource directories. The Facet allows templates from multiple sources/addons (referred to as
+ * providers) to be installed in a directory in the project structure.
+ * 
+ * For instance, templates from the javaee addon could be installed into the 'javaee' sub-directory, while templates
+ * from the angularjs addon could be installed into the 'angularjs' sub-directory. The name of the provider is
+ * determined by the provider, and only serves as a qualifier to locate templates that may be similarly named.
+ * 
+ * @author Vineet Reynolds
+ */
+public interface TemplateFacet extends ProjectFacet
+{
+   /**
+    * Get the {@link org.jboss.forge.addon.resource.DirectoryResource} representing the directory this
+    * {@link org.jboss.forge.addon.projects.Project} uses to store templates across all providers.
+    */
+   public DirectoryResource getRootTemplateDirectory();
+
+   /**
+    * Get the {@link org.jboss.forge.addon.resource.DirectoryResource} representing the directory this
+    * {@link org.jboss.forge.addon.projects.Project} uses to store templates for the specified provider.
+    */
+   public DirectoryResource getTemplateDirectory(String provider);
+
+   /**
+    * Return the {@link org.jboss.forge.addon.resource.FileResource} at the given path relative to
+    * {@link #getTemplateDirectory(String)}. The {@link org.jboss.forge.addon.resource.FileResource} object is returned
+    * regardless of whether the target actually exists. To determine if the file exists, you should call
+    * {@link org.jboss.forge.addon.resource.FileResource#exists()} on the return value of this method.
+    */
+   FileResource<?> getResource(String provider, String relativePath);
+
+}


### PR DESCRIPTION
This adds support for a Facet that is activated when the src/main/templates directory is present in a Maven project. Templates present in this directory can be retrieved through this Facet. Templates can also be added to this directory.

Extracted and refactored from the Forge 1 scaffold-x plugin.
