### PR TITLE
Introduced a Template class into the Template SPI.

### DIFF
--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/rest/generator/dto/DTOClassBuilder.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/rest/generator/dto/DTOClassBuilder.java
@@ -20,6 +20,7 @@ import org.jboss.forge.addon.parser.java.beans.Property;
 import org.jboss.forge.addon.resource.ResourceFactory;
 import org.jboss.forge.addon.templates.TemplateProcessor;
 import org.jboss.forge.addon.templates.TemplateProcessorFactory;
+import org.jboss.forge.addon.templates.freemarker.FreemarkerTemplate;
 import org.jboss.forge.parser.JavaParser;
 import org.jboss.forge.parser.java.Field;
 import org.jboss.forge.parser.java.JavaClass;
@@ -56,15 +57,13 @@ public class DTOClassBuilder
       this.topLevel = topLevel;
       this.copyCtorBuilder = new StringBuilder();
       this.assembleJPABuilder = new StringBuilder();
-      this.initializeJPAEntityFromId = processorFactory.fromTemplate(resourceFactory.create(getClass()
-               .getResource(
-                        "InitializeJPAEntityFromId.jv")));
-      this.assembleCollection = processorFactory.fromTemplate(resourceFactory.create(getClass().getResource(
-               "AssembleCollection.jv")));
+      this.initializeJPAEntityFromId = processorFactory.fromTemplate(new FreemarkerTemplate(resourceFactory
+               .create(getClass().getResource("InitializeJPAEntityFromId.jv"))));
+      this.assembleCollection = processorFactory.fromTemplate(new FreemarkerTemplate(resourceFactory.create(getClass()
+               .getResource("AssembleCollection.jv"))));
 
-      this.initializeNestedDTOCollection = processorFactory.fromTemplate(resourceFactory.create(getClass()
-               .getResource(
-                        "InitializeNestedDTOCollection.jv")));
+      this.initializeNestedDTOCollection = processorFactory.fromTemplate(new FreemarkerTemplate(resourceFactory
+               .create(getClass().getResource("InitializeNestedDTOCollection.jv"))));
 
       initName();
       initClassStructure();

--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/rest/generator/impl/EntityBasedResourceGenerator.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/rest/generator/impl/EntityBasedResourceGenerator.java
@@ -24,6 +24,7 @@ import org.jboss.forge.addon.resource.Resource;
 import org.jboss.forge.addon.resource.ResourceFactory;
 import org.jboss.forge.addon.templates.TemplateProcessor;
 import org.jboss.forge.addon.templates.TemplateProcessorFactory;
+import org.jboss.forge.addon.templates.freemarker.FreemarkerTemplate;
 import org.jboss.forge.parser.JavaParser;
 import org.jboss.forge.parser.java.JavaClass;
 
@@ -72,7 +73,7 @@ public class EntityBasedResourceGenerator implements RestResourceGenerator
       map.put("resourcePath", resourcePath);
 
       Resource<URL> templateResource = resourceFactory.create(getClass().getResource("Endpoint.jv"));
-      TemplateProcessor processor = processorFactory.fromTemplate(templateResource);
+      TemplateProcessor processor = processorFactory.fromTemplate(new FreemarkerTemplate(templateResource));
       String output = processor.process(map);
       JavaClass resource = JavaParser.parse(JavaClass.class, output);
       resource.addImport(entity.getQualifiedName());

--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/rest/generator/impl/RootAndNestedDTOResourceGenerator.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/rest/generator/impl/RootAndNestedDTOResourceGenerator.java
@@ -38,6 +38,7 @@ import org.jboss.forge.addon.resource.Resource;
 import org.jboss.forge.addon.resource.ResourceFactory;
 import org.jboss.forge.addon.templates.TemplateProcessor;
 import org.jboss.forge.addon.templates.TemplateProcessorFactory;
+import org.jboss.forge.addon.templates.freemarker.FreemarkerTemplate;
 import org.jboss.forge.parser.JavaParser;
 import org.jboss.forge.parser.java.JavaClass;
 import org.jboss.forge.parser.java.JavaSource;
@@ -92,7 +93,7 @@ public class RootAndNestedDTOResourceGenerator implements RestResourceGenerator
       map.put("resourcePath", resourcePath);
 
       Resource<URL> templateResource = resourceFactory.create(getClass().getResource("EndpointWithDTO.jv"));
-      TemplateProcessor processor = processorFactory.fromTemplate(templateResource);
+      TemplateProcessor processor = processorFactory.fromTemplate(new FreemarkerTemplate(templateResource));
       String output = processor.process(map);
       JavaClass resource = JavaParser.parse(JavaClass.class, output);
       resource.addImport(rootDto.getQualifiedName());

--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/facets/MavenTemplateFacet.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/facets/MavenTemplateFacet.java
@@ -37,12 +37,6 @@ public class MavenTemplateFacet extends AbstractFacet<Project> implements Templa
    }
 
    @Override
-   public DirectoryResource getTemplateDirectory(String provider)
-   {
-      return this.getRootTemplateDirectory().getChildDirectory(provider);
-   }
-
-   @Override
    public boolean isInstalled()
    {
       Project project = getFaceted();
@@ -60,9 +54,9 @@ public class MavenTemplateFacet extends AbstractFacet<Project> implements Templa
    }
 
    @Override
-   public FileResource<?> getResource(final String provider, final String relativePath)
+   public FileResource<?> getResource(final String path)
    {
-      return (FileResource<?>) getTemplateDirectory(provider).getChild(relativePath);
+      return (FileResource<?>) getRootTemplateDirectory().getChild(path);
    }
 
 }

--- a/projects/api/src/main/java/org/jboss/forge/addon/projects/facets/TemplateFacet.java
+++ b/projects/api/src/main/java/org/jboss/forge/addon/projects/facets/TemplateFacet.java
@@ -16,7 +16,8 @@ import org.jboss.forge.addon.resource.FileResource;
  * 
  * For instance, templates from the javaee addon could be installed into the 'javaee' sub-directory, while templates
  * from the angularjs addon could be installed into the 'angularjs' sub-directory. The name of the provider is
- * determined by the provider, and only serves as a qualifier to locate templates that may be similarly named.
+ * determined by the provider, and only serves as a qualifier to locate templates that may be similarly named. Providers
+ * are expected to use unique qualifiers; fully-qualified provider names are recommended.
  * 
  * @author Vineet Reynolds
  */
@@ -29,17 +30,13 @@ public interface TemplateFacet extends ProjectFacet
    public DirectoryResource getRootTemplateDirectory();
 
    /**
-    * Get the {@link org.jboss.forge.addon.resource.DirectoryResource} representing the directory this
-    * {@link org.jboss.forge.addon.projects.Project} uses to store templates for the specified provider.
-    */
-   public DirectoryResource getTemplateDirectory(String provider);
-
-   /**
     * Return the {@link org.jboss.forge.addon.resource.FileResource} at the given path relative to
-    * {@link #getTemplateDirectory(String)}. The {@link org.jboss.forge.addon.resource.FileResource} object is returned
+    * {@link #getRootTemplateDirectory()}. The {@link org.jboss.forge.addon.resource.FileResource} object is returned
     * regardless of whether the target actually exists. To determine if the file exists, you should call
     * {@link org.jboss.forge.addon.resource.FileResource#exists()} on the return value of this method.
+    * 
+    * @param path The path to the template
     */
-   FileResource<?> getResource(String provider, String relativePath);
+   FileResource<?> getResource(String path);
 
 }

--- a/templates/api/src/main/java/org/jboss/forge/addon/templates/TemplateProcessorFactory.java
+++ b/templates/api/src/main/java/org/jboss/forge/addon/templates/TemplateProcessorFactory.java
@@ -6,14 +6,19 @@
  */
 package org.jboss.forge.addon.templates;
 
-import org.jboss.forge.addon.resource.Resource;
-
 /**
- * Creates a {@link TemplateProcessor} based on a {@link Resource}
+ * Creates a {@link TemplateProcessor} based on a {@link Template}
  * 
  * @author <a href="ggastald@redhat.com">George Gastaldi</a>
  */
 public interface TemplateProcessorFactory
 {
-   TemplateProcessor fromTemplate(Resource<?> template);
+   /**
+    * Create a {@link TemplateProcessor} for the supplied {@link Template}. The created TemplateProcessor is associated
+    * with a template engine, and can be provided with a data model to eventually produce some output.
+    * 
+    * @param template The template for which the processor is to be created
+    * @return A {@link TemplateProcessor} instance
+    */
+   TemplateProcessor fromTemplate(Template template);
 }

--- a/templates/impl/src/main/java/org/jboss/forge/addon/templates/TemplateProcessorFactoryImpl.java
+++ b/templates/impl/src/main/java/org/jboss/forge/addon/templates/TemplateProcessorFactoryImpl.java
@@ -10,7 +10,6 @@ package org.jboss.forge.addon.templates;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.jboss.forge.addon.resource.Resource;
 import org.jboss.forge.furnace.services.Imported;
 import org.jboss.forge.furnace.util.Assert;
 
@@ -25,7 +24,7 @@ public class TemplateProcessorFactoryImpl implements TemplateProcessorFactory
    private Imported<TemplateGenerator> generators;
 
    @Override
-   public TemplateProcessor fromTemplate(Resource<?> template)
+   public TemplateProcessor fromTemplate(Template template)
    {
       Assert.notNull(template, "Template resource cannot be null");
       Assert.isTrue(template.exists(), "Template does not exist: " + template);

--- a/templates/impl/src/main/java/org/jboss/forge/addon/templates/TemplateProcessorImpl.java
+++ b/templates/impl/src/main/java/org/jboss/forge/addon/templates/TemplateProcessorImpl.java
@@ -21,13 +21,13 @@ import org.jboss.forge.addon.resource.Resource;
 public class TemplateProcessorImpl implements TemplateProcessor
 {
    private final TemplateGenerator generator;
-   private final Resource<?> resource;
+   private final Template template;
 
-   TemplateProcessorImpl(TemplateGenerator generator, Resource<?> resource)
+   TemplateProcessorImpl(TemplateGenerator generator, Template template)
    {
       super();
       this.generator = generator;
-      this.resource = resource;
+      this.template = template;
    }
 
    @Override
@@ -41,6 +41,6 @@ public class TemplateProcessorImpl implements TemplateProcessor
    @Override
    public void process(Object dataModel, Writer output) throws IOException
    {
-      generator.process(dataModel, resource, output);
+      generator.process(dataModel, template, output);
    }
 }

--- a/templates/impl/src/main/java/org/jboss/forge/addon/templates/freemarker/FreemarkerTemplate.java
+++ b/templates/impl/src/main/java/org/jboss/forge/addon/templates/freemarker/FreemarkerTemplate.java
@@ -1,0 +1,19 @@
+package org.jboss.forge.addon.templates.freemarker;
+
+import org.jboss.forge.addon.resource.Resource;
+import org.jboss.forge.addon.templates.Template;
+
+/**
+ * An abstract representation of a Freemarker template. Consumers of this class create instances of it with
+ * {@link Resource} instances to wrap Freemarker template resources. This class is used to distinguish Freemarker
+ * templates from other templates.
+ * 
+ * @author Vineet Reynolds
+ */
+public class FreemarkerTemplate extends Template
+{
+   public FreemarkerTemplate(Resource<?> resource)
+   {
+      super(resource);
+   }
+}

--- a/templates/impl/src/main/java/org/jboss/forge/addon/templates/freemarker/FreemarkerTemplateGenerator.java
+++ b/templates/impl/src/main/java/org/jboss/forge/addon/templates/freemarker/FreemarkerTemplateGenerator.java
@@ -13,10 +13,9 @@ import java.io.Writer;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.jboss.forge.addon.resource.Resource;
+import org.jboss.forge.addon.templates.Template;
 import org.jboss.forge.addon.templates.TemplateGenerator;
 
-import freemarker.template.Template;
 import freemarker.template.TemplateException;
 
 /**
@@ -33,12 +32,12 @@ public class FreemarkerTemplateGenerator implements TemplateGenerator
    private ResourceTemplateLoader loader;
 
    @Override
-   public void process(Object dataModel, Resource<?> resource, Writer writer) throws IOException
+   public void process(Object dataModel, Template template, Writer writer) throws IOException
    {
-      String id = loader.register(resource);
+      String id = loader.register(template.getResource());
       try
       {
-         Template templateFile = getFreemarkerConfig().getTemplate(id);
+         freemarker.template.Template templateFile = getFreemarkerConfig().getTemplate(id);
          templateFile.process(dataModel, writer);
          writer.flush();
       }
@@ -53,9 +52,9 @@ public class FreemarkerTemplateGenerator implements TemplateGenerator
    }
 
    @Override
-   public boolean handles(Resource<?> template)
+   public boolean handles(Template template)
    {
-      return true;
+      return template instanceof FreemarkerTemplate;
    }
 
    public freemarker.template.Configuration getFreemarkerConfig()

--- a/templates/spi/src/main/java/org/jboss/forge/addon/templates/Template.java
+++ b/templates/spi/src/main/java/org/jboss/forge/addon/templates/Template.java
@@ -1,0 +1,42 @@
+package org.jboss.forge.addon.templates;
+
+import org.jboss.forge.addon.resource.Resource;
+import org.jboss.forge.furnace.util.Assert;
+
+/**
+ * An abstract representation of a template. Concrete instances of this class are used to wrap {@link Resource}
+ * instances representing template resources.
+ * 
+ * @author Vineet Reynolds
+ */
+public abstract class Template
+{
+
+   final Resource<?> resource;
+
+   protected Template(Resource<?> resource)
+   {
+      Assert.notNull(resource, "The provided resource cannot be null.");
+      this.resource = resource;
+   }
+
+   /**
+    * Fetches the underlying resource associated with this Template instance.
+    * 
+    * @return the resource associated with this instance
+    */
+   public Resource<?> getResource()
+   {
+      return resource;
+   }
+
+   /**
+    * Indicates whether the template exists or not, usually through it's underlying resource.
+    * 
+    * @return whether the template exists or not
+    */
+   public boolean exists()
+   {
+      return resource.exists();
+   }
+}

--- a/templates/spi/src/main/java/org/jboss/forge/addon/templates/TemplateGenerator.java
+++ b/templates/spi/src/main/java/org/jboss/forge/addon/templates/TemplateGenerator.java
@@ -19,13 +19,13 @@ import org.jboss.forge.addon.resource.Resource;
 public interface TemplateGenerator
 {
    /**
-    * Returns true if the given resource instance is handled by this {@link TemplateGenerator}
+    * Returns true if the given template can be handled by this {@link TemplateGenerator}
     */
-   public boolean handles(Resource<?> template);
+   public boolean handles(Template template);
 
    /**
-    * Processes the template specified by the {@link Resource} parameter and writes the output to the {@link Writer}
+    * Processes the template specified by the {@link Template} parameter and writes the output to the {@link Writer}
     * parameter
     */
-   public void process(Object dataModel, Resource<?> template, Writer writer) throws IOException;
+   public void process(Object dataModel, Template template, Writer writer) throws IOException;
 }

--- a/templates/tests/src/test/java/org/jboss/forge/addon/templates/TemplateTestCase.java
+++ b/templates/tests/src/test/java/org/jboss/forge/addon/templates/TemplateTestCase.java
@@ -17,6 +17,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.forge.addon.resource.FileResource;
 import org.jboss.forge.addon.resource.Resource;
 import org.jboss.forge.addon.resource.ResourceFactory;
+import org.jboss.forge.addon.templates.freemarker.FreemarkerTemplate;
 import org.jboss.forge.arquillian.AddonDependency;
 import org.jboss.forge.arquillian.Dependencies;
 import org.jboss.forge.arquillian.archive.ForgeArchive;
@@ -71,7 +72,7 @@ public class TemplateTestCase
       tempFile.deleteOnExit();
       FileResource resource = resourceFactory.create(tempFile).reify(FileResource.class);
       resource.setContents(template);
-      TemplateProcessor processor = templateProcessorFactory.fromTemplate(resource);
+      TemplateProcessor processor = templateProcessorFactory.fromTemplate(new FreemarkerTemplate(resource));
       String actual = processor.process(Collections.singletonMap("name", "JBoss Forge"));
       Assert.assertEquals(expected, actual);
    }
@@ -83,7 +84,7 @@ public class TemplateTestCase
       Assert.assertNotNull(template);
       String expected = "Hello JBoss Forge!";
       Resource<?> resource = resourceFactory.create(template);
-      TemplateProcessor processor = templateProcessorFactory.fromTemplate(resource);
+      TemplateProcessor processor = templateProcessorFactory.fromTemplate(new FreemarkerTemplate(resource));
       String actual = processor.process(Collections.singletonMap("name", "JBoss Forge"));
       Assert.assertEquals(expected, actual);
    }
@@ -98,7 +99,7 @@ public class TemplateTestCase
       tempFile.deleteOnExit();
       FileResource resource = resourceFactory.create(tempFile).reify(FileResource.class);
       resource.setContents(template);
-      TemplateProcessor processor = templateProcessorFactory.fromTemplate(resource);
+      TemplateProcessor processor = templateProcessorFactory.fromTemplate(new FreemarkerTemplate(resource));
       JavaBean dataModel = new JavaBean();
       dataModel.setName("JBoss Forge");
       String actual = processor.process(dataModel);


### PR DESCRIPTION
This is used to create type-safe wrappers of template resources that can be handled by a single template engine.

Also modified the TemplateFacet API to remove redundant methods. We now settle on using a reverse-FQDN based notation for identifying template locations.
