### PR TITLE
FORGE-1660 Add Has project dependency commands

### DIFF
--- a/projects/impl/src/main/java/org/jboss/forge/addon/projects/ui/dependencies/HasDependenciesCommand.java
+++ b/projects/impl/src/main/java/org/jboss/forge/addon/projects/ui/dependencies/HasDependenciesCommand.java
@@ -1,0 +1,100 @@
+package org.jboss.forge.addon.projects.ui.dependencies;
+
+import javax.inject.Inject;
+
+import org.jboss.forge.addon.dependencies.Dependency;
+import org.jboss.forge.addon.dependencies.builder.DependencyBuilder;
+import org.jboss.forge.addon.facets.constraints.FacetConstraint;
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.projects.ProjectFactory;
+import org.jboss.forge.addon.projects.facets.DependencyFacet;
+import org.jboss.forge.addon.projects.ui.AbstractProjectCommand;
+import org.jboss.forge.addon.ui.context.UIBuilder;
+import org.jboss.forge.addon.ui.context.UIContext;
+import org.jboss.forge.addon.ui.context.UIExecutionContext;
+import org.jboss.forge.addon.ui.input.UIInput;
+import org.jboss.forge.addon.ui.input.UIInputMany;
+import org.jboss.forge.addon.ui.metadata.UICommandMetadata;
+import org.jboss.forge.addon.ui.metadata.WithAttributes;
+import org.jboss.forge.addon.ui.result.Result;
+import org.jboss.forge.addon.ui.result.Results;
+import org.jboss.forge.addon.ui.util.Categories;
+import org.jboss.forge.addon.ui.util.Metadata;
+
+@FacetConstraint(DependencyFacet.class)
+public class HasDependenciesCommand extends AbstractProjectCommand
+{
+   @Override
+   public UICommandMetadata getMetadata(UIContext context)
+   {
+      return Metadata.forCommand(HasDependenciesCommand.class)
+               .description("Check one or more arguments in the current project.")
+               .name("Project: Has Dependencies")
+               .category(Categories.create("Project", "Manage"));
+   }
+
+   @Inject
+   private ProjectFactory factory;
+
+   @Inject
+   @WithAttributes(shortName = 'd', label = "Coordinates", required = true,
+            description = "The coordinates of the arguments to be checked [groupId :artifactId {:version :scope :packaging}]")
+   private UIInputMany<Dependency> arguments;
+
+   @Inject
+   @WithAttributes(shortName = 'e', label = "Effective", required = false,
+            description = "", defaultValue = "")
+   private UIInput<Boolean> effective;
+
+   @Override
+   public void initializeUI(UIBuilder builder) throws Exception
+   {
+      builder.add(arguments);
+      builder.add(effective);
+   }
+
+   @Override
+   public Result execute(UIExecutionContext context)
+   {
+      Project project = getSelectedProject(context.getUIContext());
+      final DependencyFacet deps = project.getFacet(DependencyFacet.class);
+
+      if (arguments.hasValue())
+      {
+         int numberOfGavsFound = 0;
+         int numberOfGavs = 0;
+         for (Dependency gav : arguments.getValue())
+         {
+            numberOfGavs++;
+            DependencyBuilder dep = DependencyBuilder.create(gav);
+            if(effective.getValue()) {
+               if(deps.hasEffectiveDependency(gav)) {
+                  numberOfGavsFound++;
+               }
+            } else {
+               if(deps.hasDirectDependency(dep)) {
+                  numberOfGavsFound++;
+               }
+            }
+         }
+         if(numberOfGavs == numberOfGavsFound) {
+            return Results.success("All arguments found");
+         } else {
+            return Results.fail("Missing " + (numberOfGavs - numberOfGavsFound));
+         }
+      }
+      return Results.fail("No arguments specified.");
+   }
+
+   @Override
+   protected boolean isProjectRequired()
+   {
+      return true;
+   }
+
+   @Override
+   protected ProjectFactory getProjectFactory()
+   {
+      return factory;
+   }
+}

--- a/projects/impl/src/main/java/org/jboss/forge/addon/projects/ui/dependencies/HasManagedDependenciesCommand.java
+++ b/projects/impl/src/main/java/org/jboss/forge/addon/projects/ui/dependencies/HasManagedDependenciesCommand.java
@@ -1,0 +1,101 @@
+package org.jboss.forge.addon.projects.ui.dependencies;
+
+import javax.inject.Inject;
+
+import org.jboss.forge.addon.dependencies.Dependency;
+import org.jboss.forge.addon.dependencies.builder.DependencyBuilder;
+import org.jboss.forge.addon.facets.constraints.FacetConstraint;
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.projects.ProjectFactory;
+import org.jboss.forge.addon.projects.facets.DependencyFacet;
+import org.jboss.forge.addon.projects.ui.AbstractProjectCommand;
+import org.jboss.forge.addon.ui.context.UIBuilder;
+import org.jboss.forge.addon.ui.context.UIContext;
+import org.jboss.forge.addon.ui.context.UIExecutionContext;
+import org.jboss.forge.addon.ui.input.UIInput;
+import org.jboss.forge.addon.ui.input.UIInputMany;
+import org.jboss.forge.addon.ui.metadata.UICommandMetadata;
+import org.jboss.forge.addon.ui.metadata.WithAttributes;
+import org.jboss.forge.addon.ui.result.Result;
+import org.jboss.forge.addon.ui.result.Results;
+import org.jboss.forge.addon.ui.util.Categories;
+import org.jboss.forge.addon.ui.util.Metadata;
+
+@FacetConstraint(DependencyFacet.class)
+public class HasManagedDependenciesCommand extends AbstractProjectCommand
+{
+   @Override
+   public UICommandMetadata getMetadata(UIContext context)
+   {
+      return Metadata.forCommand(HasManagedDependenciesCommand.class)
+               .description("Check one or more managed dependencies in the current project.")
+               .name("Project: Has Managed Dependencies")
+               .category(Categories.create("Project", "Manage"));
+   }
+
+   @Inject
+   private ProjectFactory factory;
+
+   @Inject
+   @WithAttributes(shortName = 'd', label = "Coordinates", required = true,
+            description = "The coordinates of the managed arguments to be checked [groupId :artifactId {:version :scope :packaging}]")
+   private UIInputMany<Dependency> arguments;
+
+   @Inject
+   @WithAttributes(shortName = 'e', label = "Effective", required = false,
+            description = "", defaultValue = "")
+   private UIInput<Boolean> effective;
+
+   @Override
+   public void initializeUI(UIBuilder builder) throws Exception
+   {
+      builder.add(arguments);
+      builder.add(effective);
+   }
+
+   @Override
+   public Result execute(UIExecutionContext context)
+   {
+      Project project = getSelectedProject(context.getUIContext());
+      final DependencyFacet deps = project.getFacet(DependencyFacet.class);
+
+      if (arguments.hasValue())
+      {
+         int numberOfGavsFound = 0;
+         int numberOfGavs = 0;
+         for (Dependency gav : arguments.getValue())
+         {
+            numberOfGavs++;
+            DependencyBuilder dep = DependencyBuilder.create(gav);
+            if(effective.getValue()) {
+               if(deps.hasEffectiveManagedDependency(gav)) {
+                  numberOfGavsFound++;
+               }
+            } else {
+               if(deps.hasDirectManagedDependency(dep)) {
+                  numberOfGavsFound++;
+               }
+            }
+         }
+         if(numberOfGavs == numberOfGavsFound) {
+            return Results.success("All arguments found");
+         } else {
+            return Results.fail("Missing " + (numberOfGavs - numberOfGavsFound));
+         }
+      }
+
+      return Results.fail("No arguments specified.");
+   }
+
+   @Override
+   protected boolean isProjectRequired()
+   {
+      return true;
+   }
+
+   @Override
+   protected ProjectFactory getProjectFactory()
+   {
+      return factory;
+   }
+}

--- a/projects/tests/src/test/java/org/jboss/forge/addon/projects/impl/ProjectDependencyCommandsTest.java
+++ b/projects/tests/src/test/java/org/jboss/forge/addon/projects/impl/ProjectDependencyCommandsTest.java
@@ -24,9 +24,13 @@ import org.jboss.forge.addon.projects.mock.MockBuildSystem;
 import org.jboss.forge.addon.projects.mock.MockProjectType;
 import org.jboss.forge.addon.projects.ui.dependencies.AddDependenciesCommand;
 import org.jboss.forge.addon.projects.ui.dependencies.AddManagedDependenciesCommand;
+import org.jboss.forge.addon.projects.ui.dependencies.HasDependenciesCommand;
+import org.jboss.forge.addon.projects.ui.dependencies.HasManagedDependenciesCommand;
 import org.jboss.forge.addon.projects.ui.dependencies.RemoveDependenciesCommand;
 import org.jboss.forge.addon.projects.ui.dependencies.RemoveManagedDependenciesCommand;
 import org.jboss.forge.addon.ui.controller.CommandController;
+import org.jboss.forge.addon.ui.result.Failed;
+import org.jboss.forge.addon.ui.result.Result;
 import org.jboss.forge.addon.ui.test.UITestHarness;
 import org.jboss.forge.arquillian.AddonDependency;
 import org.jboss.forge.arquillian.Dependencies;
@@ -359,6 +363,174 @@ public class ProjectDependencyCommandsTest
          Assert.assertTrue(project.getFacet(DependencyFacet.class).hasDirectDependency(DEPENDENCY2));
          Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectManagedDependency(DEPENDENCY2));
          Assert.assertFalse(project.getFacet(DependencyFacet.class).hasEffectiveManagedDependency(DEPENDENCY2));
+      }
+      finally
+      {
+         project.getRootDirectory().delete(true);
+      }
+   }
+
+   @Test
+   public void testHasDependencyReturnSuccessOnFound() throws Exception
+   {
+      Project project = factory.createTempProject(build);
+      try
+      {
+         installer.install(project, DEPENDENCY);
+
+         Assert.assertTrue(project.getFacet(DependencyFacet.class).hasDirectDependency(DEPENDENCY));
+         Assert.assertTrue(project.getFacet(DependencyFacet.class).hasDirectManagedDependency(DEPENDENCY));
+         Assert.assertTrue(project.getFacet(DependencyFacet.class).hasEffectiveManagedDependency(DEPENDENCY));
+
+         CommandController command = testHarness.createCommandController(HasDependenciesCommand.class,
+                  project.getRootDirectory());
+         command.initialize();
+         command.setValueFor("arguments", COORDINATES);
+         Assert.assertTrue(command.isValid());
+         Assert.assertTrue(command.canExecute());
+         Result result = command.execute();
+         Assert.assertFalse(result instanceof Failed);
+      }
+      finally
+      {
+         project.getRootDirectory().delete(true);
+      }
+   }
+
+   @Test
+   public void testHasDependencyReturnFailureOnMissing() throws Exception
+   {
+      Project project = factory.createTempProject(build);
+      try
+      {
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectDependency(DEPENDENCY));
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectManagedDependency(DEPENDENCY));
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasEffectiveManagedDependency(DEPENDENCY));
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectDependency(DEPENDENCY2));
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectManagedDependency(DEPENDENCY2));
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasEffectiveManagedDependency(DEPENDENCY2));
+
+         CommandController command = testHarness.createCommandController(HasDependenciesCommand.class,
+                  project.getRootDirectory());
+         command.initialize();
+         command.setValueFor("arguments", COORDINATES);
+         Assert.assertTrue(command.isValid());
+         Assert.assertTrue(command.canExecute());
+         Result result = command.execute();
+         Assert.assertTrue(result instanceof Failed);
+      }
+      finally
+      {
+         project.getRootDirectory().delete(true);
+      }
+   }
+
+   @Test
+   public void testHasDependencyReturnFailureOnSomeFound() throws Exception
+   {
+      Project project = factory.createTempProject(build);
+      try
+      {
+         installer.install(project, DEPENDENCY);
+
+         Assert.assertTrue(project.getFacet(DependencyFacet.class).hasDirectDependency(DEPENDENCY));
+         Assert.assertTrue(project.getFacet(DependencyFacet.class).hasDirectManagedDependency(DEPENDENCY));
+         Assert.assertTrue(project.getFacet(DependencyFacet.class).hasEffectiveManagedDependency(DEPENDENCY));
+
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectDependency(DEPENDENCY2));
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectManagedDependency(DEPENDENCY2));
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasEffectiveManagedDependency(DEPENDENCY2));
+
+         CommandController command = testHarness.createCommandController(HasDependenciesCommand.class,
+                  project.getRootDirectory());
+         command.initialize();
+         command.setValueFor("arguments", Arrays.asList(COORDINATES, COORDINATES2));
+         Assert.assertTrue(command.isValid());
+         Assert.assertTrue(command.canExecute());
+         Result result = command.execute();
+         Assert.assertTrue(result instanceof Failed);
+      }
+      finally
+      {
+         project.getRootDirectory().delete(true);
+      }
+   }
+
+   @Test
+   public void testHasManagedDependencyReturnSuccessOnFound() throws Exception
+   {
+      Project project = factory.createTempProject(build);
+      try
+      {
+         installer.installManaged(project, DEPENDENCY);
+
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectDependency(DEPENDENCY));
+         Assert.assertTrue(project.getFacet(DependencyFacet.class).hasDirectManagedDependency(DEPENDENCY));
+         Assert.assertTrue(project.getFacet(DependencyFacet.class).hasEffectiveManagedDependency(DEPENDENCY));
+
+         CommandController command = testHarness.createCommandController(HasManagedDependenciesCommand.class,
+                  project.getRootDirectory());
+         command.initialize();
+         command.setValueFor("arguments", COORDINATES);
+         Assert.assertTrue(command.isValid());
+         Assert.assertTrue(command.canExecute());
+         Result result = command.execute();
+         Assert.assertFalse(result instanceof Failed);
+      }
+      finally
+      {
+         project.getRootDirectory().delete(true);
+      }
+   }
+
+   @Test
+   public void testHasManagedDependencyReturnFailureOnMissing() throws Exception
+   {
+      Project project = factory.createTempProject(build);
+      try
+      {
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectDependency(DEPENDENCY));
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectManagedDependency(DEPENDENCY));
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasEffectiveManagedDependency(DEPENDENCY));
+
+         CommandController command = testHarness.createCommandController(HasManagedDependenciesCommand.class,
+                  project.getRootDirectory());
+         command.initialize();
+         command.setValueFor("arguments", COORDINATES);
+         Assert.assertTrue(command.isValid());
+         Assert.assertTrue(command.canExecute());
+         Result result = command.execute();
+         Assert.assertTrue(result instanceof Failed);
+      }
+      finally
+      {
+         project.getRootDirectory().delete(true);
+      }
+   }
+
+   @Test
+   public void testHasManagedDependencyReturnFailureOnSomeFound() throws Exception
+   {
+      Project project = factory.createTempProject(build);
+      try
+      {
+         installer.installManaged(project, DEPENDENCY);
+
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectDependency(DEPENDENCY));
+         Assert.assertTrue(project.getFacet(DependencyFacet.class).hasDirectManagedDependency(DEPENDENCY));
+         Assert.assertTrue(project.getFacet(DependencyFacet.class).hasEffectiveManagedDependency(DEPENDENCY));
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectDependency(DEPENDENCY2));
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasDirectManagedDependency(DEPENDENCY2));
+         Assert.assertFalse(project.getFacet(DependencyFacet.class).hasEffectiveManagedDependency(DEPENDENCY2));
+
+         CommandController command = testHarness.createCommandController(HasManagedDependenciesCommand.class,
+                  project.getRootDirectory());
+         command.initialize();
+         command.setValueFor("arguments", Arrays.asList(COORDINATES, COORDINATES2));
+         Assert.assertTrue(command.isValid());
+         Assert.assertTrue(command.canExecute());
+         Result result = command.execute();
+         Assert.assertTrue(result instanceof Failed);
       }
       finally
       {


### PR DESCRIPTION
New commands:
- project-has-dependencies
- project-has-managed-dependencies

Both have a -e boolean switch to check effective or direct dependency(default).
