### PR TITLE
Add scaffold-spi to Forge BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -363,6 +363,12 @@
          </dependency>
          <dependency>
             <groupId>org.jboss.forge.addon</groupId>
+            <artifactId>scaffold-spi</artifactId>
+            <version>${project.version}</version>
+            <classifier>forge-addon</classifier>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.forge.addon</groupId>
             <artifactId>scaffold-faces</artifactId>
             <version>${project.version}</version>
             <classifier>forge-addon</classifier>


### PR DESCRIPTION
I found this missing, but I wasnt sure if this was not present intentionally.
