### PR TITLE
Add a SetVersionCommand for the Java Compiled Projects

### DIFF
--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/facets/MavenJavaCompilerFacet.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/facets/MavenJavaCompilerFacet.java
@@ -51,12 +51,63 @@ public class MavenJavaCompilerFacet extends AbstractFacet<Project> implements Ja
       MavenFacet maven = getFaceted().getFacet(MavenFacet.class);
       Model pom = maven.getModel();
       Properties properties = pom.getProperties();
-      // TODO: Use System.getProperty("java.version") ?
-      String javaVersion = "1.7";
-      properties.setProperty(MAVEN_COMPILER_SOURCE_KEY, javaVersion);
-      properties.setProperty(MAVEN_COMPILER_TARGET_KEY, javaVersion);
+
+      setMavenCompilerSource(properties, DEFAULT_COMPILER_VERSION.toString());
+      setMavenCompilerTarget(properties, DEFAULT_COMPILER_VERSION.toString());
       properties.setProperty(MAVEN_COMPILER_ENCODING_KEY, "UTF-8");
       maven.setModel(pom);
       return true;
    }
+
+   @Override
+   public void setSourceCompilerVersion(CompilerVersion version)
+   {
+      if (version != null)
+      {
+         MavenFacet maven = getFaceted().getFacet(MavenFacet.class);
+         Model pom = maven.getModel();
+         setMavenCompilerSource(pom.getProperties(), version.toString());
+         maven.setModel(pom);
+      }
+   }
+
+   @Override
+   public void setTargetCompilerVersion(CompilerVersion version)
+   {
+      if (version != null)
+      {
+         MavenFacet maven = getFaceted().getFacet(MavenFacet.class);
+         Model pom = maven.getModel();
+         setMavenCompilerTarget(pom.getProperties(), version.toString());
+         maven.setModel(pom);
+      }
+   }
+
+   @Override public CompilerVersion getSourceCompilerVersion()
+   {
+      MavenFacet maven = getFaceted().getFacet(MavenFacet.class);
+      Model pom = maven.getModel();
+      String sourceVersion = pom.getProperties().getProperty(MAVEN_COMPILER_SOURCE_KEY);
+      return sourceVersion != null ? CompilerVersion.getValue(sourceVersion) : DEFAULT_COMPILER_VERSION;
+   }
+
+   @Override public CompilerVersion getTargetCompilerVersion()
+   {
+      MavenFacet maven = getFaceted().getFacet(MavenFacet.class);
+      Model pom = maven.getModel();
+      String targetVersion = pom.getProperties().getProperty(MAVEN_COMPILER_TARGET_KEY);
+      return targetVersion != null ? CompilerVersion.getValue(targetVersion) : DEFAULT_COMPILER_VERSION;
+   }
+
+   private Properties setMavenCompilerSource(Properties mavenProps, String sourceCompilerVersion)
+   {
+      mavenProps.setProperty(MAVEN_COMPILER_SOURCE_KEY, sourceCompilerVersion);
+      return mavenProps;
+   }
+
+   private void setMavenCompilerTarget(Properties mavenProps, String targetCompilerVersion)
+   {
+      mavenProps.setProperty(MAVEN_COMPILER_TARGET_KEY, targetCompilerVersion);
+   }
+
 }

--- a/parser-java/api/src/main/java/org/jboss/forge/addon/parser/java/facets/JavaCompilerFacet.java
+++ b/parser-java/api/src/main/java/org/jboss/forge/addon/parser/java/facets/JavaCompilerFacet.java
@@ -16,5 +16,48 @@ import org.jboss.forge.addon.projects.ProjectFacet;
  */
 public interface JavaCompilerFacet extends ProjectFacet
 {
+   public enum CompilerVersion
+   {
+      JAVA_1_3("1.3"),
+      JAVA_1_4("1.4"),
+      JAVA_1_5("1.5"),
+      JAVA_1_6("1.6"),
+      JAVA_1_7("1.7"),
+      JAVA_1_8("1.8");
 
+      String text;
+
+      private CompilerVersion(String text)
+      {
+         this.text = text;
+      }
+
+      @Override
+      public String toString()
+      {
+         return text;
+      }
+
+      public static CompilerVersion getValue(String value)
+      {
+         for (CompilerVersion version : values())
+         {
+            if (version.toString().equals(value))
+            {
+               return version;
+            }
+         }
+         throw new IllegalArgumentException(value + " is not a supported Java compiler version.");
+      }
+   }
+
+   public static final CompilerVersion DEFAULT_COMPILER_VERSION = CompilerVersion.JAVA_1_7;
+
+   public void setSourceCompilerVersion(CompilerVersion version);
+
+   public void setTargetCompilerVersion(CompilerVersion version);
+
+   public CompilerVersion getSourceCompilerVersion();
+
+   public CompilerVersion getTargetCompilerVersion();
 }

--- a/parser-java/impl/src/main/java/org/jboss/forge/addon/parser/java/ui/SetCompilerVersionCommand.java
+++ b/parser-java/impl/src/main/java/org/jboss/forge/addon/parser/java/ui/SetCompilerVersionCommand.java
@@ -1,0 +1,95 @@
+package org.jboss.forge.addon.parser.java.ui;
+
+import org.jboss.forge.addon.facets.constraints.FacetConstraint;
+import org.jboss.forge.addon.parser.java.facets.JavaCompilerFacet;
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.projects.ProjectFactory;
+import org.jboss.forge.addon.projects.ui.AbstractProjectCommand;
+import org.jboss.forge.addon.ui.context.UIBuilder;
+import org.jboss.forge.addon.ui.context.UIContext;
+import org.jboss.forge.addon.ui.context.UIExecutionContext;
+import org.jboss.forge.addon.ui.input.UISelectOne;
+import org.jboss.forge.addon.ui.metadata.UICommandMetadata;
+import org.jboss.forge.addon.ui.metadata.WithAttributes;
+import org.jboss.forge.addon.ui.result.Result;
+import org.jboss.forge.addon.ui.result.Results;
+import org.jboss.forge.addon.ui.util.Categories;
+import org.jboss.forge.addon.ui.util.Metadata;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.jboss.forge.addon.parser.java.facets.JavaCompilerFacet.*;
+
+/**
+ *
+ * @author <a href="ivan.st.ivanov@gmail.com">Ivan St. Ivanov</a>
+ */
+@FacetConstraint(JavaCompilerFacet.class)
+public class SetCompilerVersionCommand extends AbstractProjectCommand
+{
+   @Inject
+   @WithAttributes(label = "Java sources version")
+   private UISelectOne<JavaCompilerFacet.CompilerVersion> sourceVersion;
+
+   @Inject
+   @WithAttributes(label = "Target compilation version")
+   private UISelectOne<JavaCompilerFacet.CompilerVersion> targetVersion;
+
+   @Override public UICommandMetadata getMetadata(UIContext context)
+   {
+      return  Metadata.from(super.getMetadata(context), getClass()).name("Project: Set Compiler Version")
+               .description("Set the java sources and the target compilation version")
+               .category(Categories.create(super.getMetadata(context).getCategory(), "Project"));
+   }
+
+   @Override
+   public void initializeUI(UIBuilder builder) throws Exception
+   {
+      List<JavaCompilerFacet.CompilerVersion> values = Arrays.asList(CompilerVersion.values());
+      sourceVersion.setValueChoices(values);
+      targetVersion.setValueChoices(values);
+      builder.add(sourceVersion).add(targetVersion);
+   }
+
+   @Override
+   public Result execute(UIExecutionContext context) throws Exception
+   {
+      JavaCompilerFacet facet = getJavaCompilerFacet(context);
+
+      CompilerVersion sourceVersion = this.sourceVersion.getValue() == null ? facet.getSourceCompilerVersion() : this.sourceVersion.getValue();
+      CompilerVersion targetVersion = this.targetVersion.getValue() == null ? facet.getTargetCompilerVersion() : this.targetVersion.getValue();
+
+      if (sourceVersion.ordinal() > targetVersion.ordinal())
+      {
+         return Results.fail("Selected source version (" + sourceVersion.toString() +
+                  ") is higher than the target version (" + targetVersion.toString() + ").");
+      }
+
+      facet.setSourceCompilerVersion(sourceVersion);
+      facet.setTargetCompilerVersion(targetVersion);
+      return Results.success();
+   }
+
+   private JavaCompilerFacet getJavaCompilerFacet(UIExecutionContext context)
+   {
+      Project project = getSelectedProject(context);
+
+      return project.getFacet(JavaCompilerFacet.class);
+   }
+
+   @Override protected boolean isProjectRequired()
+   {
+      return true;
+   }
+
+   @Inject
+   private ProjectFactory projectFactory;
+
+   @Override protected ProjectFactory getProjectFactory()
+   {
+      return projectFactory;
+   }
+
+}

--- a/parser-java/tests/src/test/java/org/jboss/forge/addon/parser/java/ui/SetCompilerVersionCommandTest.java
+++ b/parser-java/tests/src/test/java/org/jboss/forge/addon/parser/java/ui/SetCompilerVersionCommandTest.java
@@ -1,0 +1,151 @@
+package org.jboss.forge.addon.parser.java.ui;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.addon.facets.FacetFactory;
+import org.jboss.forge.addon.maven.projects.MavenFacet;
+import org.jboss.forge.addon.parser.java.facets.JavaCompilerFacet;
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.projects.ProjectFactory;
+import org.jboss.forge.addon.ui.controller.CommandController;
+import org.jboss.forge.addon.ui.result.Failed;
+import org.jboss.forge.addon.ui.result.Result;
+import org.jboss.forge.addon.ui.result.Results;
+import org.jboss.forge.addon.ui.test.UITestHarness;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.Dependencies;
+import org.jboss.forge.arquillian.archive.ForgeArchive;
+import org.jboss.forge.furnace.repositories.AddonDependencyEntry;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static junit.framework.Assert.assertEquals;
+import static org.jboss.forge.addon.parser.java.facets.JavaCompilerFacet.CompilerVersion;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class SetCompilerVersionCommandTest
+{
+   @Deployment
+   @Dependencies({
+            @AddonDependency(name = "org.jboss.forge.addon:parser-java"),
+            @AddonDependency(name = "org.jboss.forge.addon:ui-test-harness"),
+            @AddonDependency(name = "org.jboss.forge.addon:projects"),
+            @AddonDependency(name = "org.jboss.forge.addon:maven"),
+            @AddonDependency(name = "org.jboss.forge.furnace.container:cdi")
+   })
+   public static ForgeArchive getDeployment()
+   {
+      return ShrinkWrap
+               .create(ForgeArchive.class)
+               .addBeansXML()
+               .addAsAddonDependencies(
+                        AddonDependencyEntry.create("org.jboss.forge.furnace.container:cdi"),
+                        AddonDependencyEntry.create("org.jboss.forge.addon:projects"),
+                        AddonDependencyEntry.create("org.jboss.forge.addon:parser-java"),
+                        AddonDependencyEntry.create("org.jboss.forge.addon:ui-test-harness"),
+                        AddonDependencyEntry.create("org.jboss.forge.addon:maven"),
+                        AddonDependencyEntry.create("org.jboss.forge.addon:ui-test-harness")
+               );
+   }
+
+   @Inject
+   private ProjectFactory projectFactory;
+
+   @Inject
+   private UITestHarness testHarness;
+
+   @Inject
+   private FacetFactory facetFactory;
+
+   private Project project;
+
+   private CommandController commandController;
+
+   @Before
+   public void setup() throws Exception
+   {
+      project = projectFactory.createTempProject();
+      facetFactory.install(project, JavaCompilerFacet.class);
+      assertDefaultVersions();
+      commandController = testHarness.createCommandController(SetCompilerVersionCommand.class, project.getRoot());
+   }
+
+   private void assertDefaultVersions()
+   {
+      assertSourceVersion(JavaCompilerFacet.DEFAULT_COMPILER_VERSION);
+      assertTargetVersion(JavaCompilerFacet.DEFAULT_COMPILER_VERSION);
+   }
+
+   @Test
+   public void testSetBothVersions() throws Exception
+   {
+      commandController.initialize();
+      commandController.setValueFor("sourceVersion", CompilerVersion.JAVA_1_6);
+      commandController.setValueFor("targetVersion", CompilerVersion.JAVA_1_6);
+      commandController.execute();
+      assertSourceVersion(CompilerVersion.JAVA_1_6);
+      assertTargetVersion(CompilerVersion.JAVA_1_6);
+   }
+
+   @Test
+   public void testSetSourceVersionOnly() throws Exception
+   {
+      commandController.initialize();
+      commandController.setValueFor("sourceVersion", CompilerVersion.JAVA_1_4);
+      commandController.execute();
+      assertSourceVersion(CompilerVersion.JAVA_1_4);
+      assertTargetVersion(JavaCompilerFacet.DEFAULT_COMPILER_VERSION);
+   }
+
+   @Test
+   public void testSetTargetVersionOnly() throws Exception
+   {
+      commandController.initialize();
+      commandController.setValueFor("targetVersion", CompilerVersion.JAVA_1_8);
+      commandController.execute();
+      assertSourceVersion(JavaCompilerFacet.DEFAULT_COMPILER_VERSION);
+      assertTargetVersion(CompilerVersion.JAVA_1_8);
+   }
+
+   @Test
+   public void testSetSourceVersionHigherThanTargetVersion() throws Exception
+   {
+      commandController.initialize();
+      commandController.setValueFor("sourceVersion", CompilerVersion.JAVA_1_5);
+      commandController.setValueFor("targetVersion", CompilerVersion.JAVA_1_4);
+      assertTrue(commandController.execute() instanceof Failed);
+   }
+
+   @Test
+   public void testSetSourceVersionHigherThanDefaultTargetVersion() throws Exception
+   {
+      commandController.initialize();
+      commandController.setValueFor("sourceVersion", CompilerVersion.JAVA_1_8);
+      assertTrue(commandController.execute() instanceof Failed);
+   }
+
+   @Test
+   public void testSetTargetVersionLowerThanDefaultSourceVersion() throws Exception
+   {
+      commandController.initialize();
+      commandController.setValueFor("targetVersion", CompilerVersion.JAVA_1_3);
+      assertTrue(commandController.execute() instanceof Failed);
+   }
+
+   private void assertSourceVersion(CompilerVersion version)
+   {
+      MavenFacet mavenFacet = project.getFacet(MavenFacet.class);
+      assertEquals(version.toString(), mavenFacet.getProperties().get("maven.compiler.source"));
+   }
+
+   private void assertTargetVersion(CompilerVersion versionString)
+   {
+      MavenFacet mavenFacet = project.getFacet(MavenFacet.class);
+      assertEquals(versionString.toString(), mavenFacet.getProperties().get("maven.compiler.target"));
+   }
+}


### PR DESCRIPTION
In addition to last night's pull request:
- Added support for Java versions from 1.3 to 1.8
- Added a check upon execution that compares source to target (source should not be greater). If one of these is not set (the inputs are not mandatory), the value is read from the project
