### PR TITLE
FORGE-1450 - Forge will correctly create enum attribute on entity.

### DIFF
--- a/javaee/tests/src/main/java/org/jboss/forge/addon/javaee/ProjectHelper.java
+++ b/javaee/tests/src/main/java/org/jboss/forge/addon/javaee/ProjectHelper.java
@@ -22,16 +22,19 @@ import org.jboss.forge.addon.javaee.jpa.JPAFacet_2_0;
 import org.jboss.forge.addon.javaee.jpa.PersistenceOperations;
 import org.jboss.forge.addon.javaee.servlet.ServletFacet_3_1;
 import org.jboss.forge.addon.javaee.validation.ValidationFacet;
+import org.jboss.forge.addon.parser.java.facets.JavaSourceFacet;
 import org.jboss.forge.addon.parser.java.projects.JavaProjectType;
 import org.jboss.forge.addon.parser.java.projects.JavaWebProjectType;
 import org.jboss.forge.addon.parser.java.resources.JavaResource;
 import org.jboss.forge.addon.projects.Project;
 import org.jboss.forge.addon.projects.ProjectFactory;
 import org.jboss.forge.addon.projects.facets.MetadataFacet;
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.source.JavaEnumSource;
 
 /**
  * Helps with the configuration of a project
- * 
+ *
  * @author <a href="ggastald@redhat.com">George Gastaldi</a>
  */
 public class ProjectHelper
@@ -127,5 +130,14 @@ public class ProjectHelper
    {
       String packageName = project.getFacet(MetadataFacet.class).getTopLevelPackage() + ".model";
       return persistenceOperations.newEntity(project, entityName, packageName, GenerationType.AUTO);
+   }
+
+   public JavaResource createEmptyEnum(Project project, String enumName) throws IOException
+   {
+      JavaSourceFacet javaSourceFacet = project.getFacet(JavaSourceFacet.class);
+      JavaEnumSource enumSource = Roaster.create(JavaEnumSource.class).setName(enumName);
+      String packageName = project.getFacet(MetadataFacet.class).getTopLevelPackage() + ".model";
+      enumSource.setPackage(packageName);
+      return javaSourceFacet.saveJavaSource(enumSource);
    }
 }

--- a/javaee/tests/src/test/java/org/jboss/forge/addon/javaee/ProjectHelperTest.java
+++ b/javaee/tests/src/test/java/org/jboss/forge/addon/javaee/ProjectHelperTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * 
+ *
  * @author <a href="ggastald@redhat.com">George Gastaldi</a>
  */
 @RunWith(Arquillian.class)
@@ -130,6 +130,19 @@ public class ProjectHelperTest
       projectHelper.installJPA_2_0(project);
       JavaResource jpaEntity = projectHelper.createJPAEntity(project, "Customer");
       Assert.assertTrue(jpaEntity.exists());
+      Resource<?> build = project.getFacet(PackagingFacet.class).createBuilder().runTests(false).build();
+      Assert.assertNotNull(build);
+      Assert.assertTrue("Build artifact does not exist", build.exists());
+   }
+
+   @Test
+   public void testEnumCreation() throws Exception
+   {
+      Project project = projectHelper.createWebProject();
+      projectHelper.installJPA_2_0(project);
+      JavaResource enumEntity = projectHelper.createEmptyEnum(project, "CustomerType");
+      Assert.assertTrue(enumEntity.exists());
+      Assert.assertTrue(enumEntity.getJavaType().isEnum());
       Resource<?> build = project.getFacet(PackagingFacet.class).createBuilder().runTests(false).build();
       Assert.assertNotNull(build);
       Assert.assertTrue("Build artifact does not exist", build.exists());

--- a/javaee/tests/src/test/java/org/jboss/forge/addon/javaee/jpa/NewFieldWizardTest.java
+++ b/javaee/tests/src/test/java/org/jboss/forge/addon/javaee/jpa/NewFieldWizardTest.java
@@ -11,6 +11,8 @@ import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
 import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
 import javax.persistence.Transient;
@@ -231,5 +233,104 @@ public class NewFieldWizardTest
       Assert.assertEquals(FetchType.EAGER, field.getAnnotation(OneToMany.class).getEnumValue(FetchType.class, "fetch"));
       Assert.assertEquals("Set", field.getType().getName());
    }
+
+   @Test
+   public void testNewEnumField() throws Exception
+   {
+      JavaResource entity = projectHelper.createJPAEntity(project, "Customer");
+      JavaResource enumEntity = projectHelper.createEmptyEnum(project, "CustomerType");
+
+      try (WizardCommandController controller = uiTestHarness.createWizardController(NewFieldWizard.class,
+               project.getRoot()))
+      {
+         controller.initialize();
+         Assert.assertTrue(controller.isEnabled());
+         controller.setValueFor("targetEntity", entity);
+         Assert.assertFalse(controller.canExecute());
+         controller.setValueFor("named", "customerType");
+         controller.setValueFor("type", enumEntity.getJavaType().getCanonicalName());
+         Assert.assertFalse(controller.canMoveToNextStep());
+         Assert.assertTrue(controller.canExecute());
+         Result result = controller.execute();
+         Assert.assertFalse(result instanceof Failed);
+         Assert.assertEquals("Field customerType created", result.getMessage());
+      }
+
+      JavaClass<?> javaClass = entity.getJavaType();
+      Assert.assertTrue(javaClass.hasField("customerType"));
+      final Field<?> field = javaClass.getField("customerType");
+      Assert.assertEquals("CustomerType", field.getType().getName());
+      Assert.assertFalse(field.hasAnnotation(Column.class));
+      Assert.assertTrue(field.hasAnnotation(Enumerated.class));
+      Assert.assertTrue(field.getAnnotation(Enumerated.class).getValues().isEmpty());
+   }
+
+   @Test
+   public void testNewEnumFieldWithColumnName() throws Exception
+   {
+      JavaResource entity = projectHelper.createJPAEntity(project, "Customer");
+      JavaResource enumEntity = projectHelper.createEmptyEnum(project, "CustomerType");
+
+      try (WizardCommandController controller = uiTestHarness.createWizardController(NewFieldWizard.class,
+               project.getRoot()))
+      {
+         controller.initialize();
+         Assert.assertTrue(controller.isEnabled());
+         controller.setValueFor("targetEntity", entity);
+         Assert.assertFalse(controller.canExecute());
+         controller.setValueFor("named", "customerType");
+         controller.setValueFor("type", enumEntity.getJavaType().getCanonicalName());
+         controller.setValueFor("columnName", "CUSTOMER_TYPE_COLUMN");
+         Assert.assertFalse(controller.canMoveToNextStep());
+         Assert.assertTrue(controller.canExecute());
+         Result result = controller.execute();
+         Assert.assertFalse(result instanceof Failed);
+         Assert.assertEquals("Field customerType created", result.getMessage());
+      }
+
+      JavaClass<?> javaClass = entity.getJavaType();
+      Assert.assertTrue(javaClass.hasField("customerType"));
+      final Field<?> field = javaClass.getField("customerType");
+      Assert.assertEquals("CustomerType", field.getType().getName());
+      Assert.assertTrue(field.hasAnnotation(Column.class));
+      Assert.assertEquals("CUSTOMER_TYPE_COLUMN", field.getAnnotation(Column.class).getStringValue("name"));
+      Assert.assertTrue(field.hasAnnotation(Enumerated.class));
+      Assert.assertTrue(field.getAnnotation(Enumerated.class).getValues().isEmpty());
+   }
+
+   @Test
+   public void testNewEnumFieldWithType() throws Exception
+   {
+      JavaResource entity = projectHelper.createJPAEntity(project, "Customer");
+      JavaResource enumEntity = projectHelper.createEmptyEnum(project, "CustomerType");
+
+      try (WizardCommandController controller = uiTestHarness.createWizardController(NewFieldWizard.class,
+               project.getRoot()))
+      {
+         controller.initialize();
+         Assert.assertTrue(controller.isEnabled());
+         controller.setValueFor("targetEntity", entity);
+         Assert.assertFalse(controller.canExecute());
+         controller.setValueFor("named", "customerType");
+         controller.setValueFor("type", enumEntity.getJavaType().getCanonicalName());
+         controller.setValueFor("enumType", EnumType.STRING);
+         Assert.assertFalse(controller.canMoveToNextStep());
+         Assert.assertTrue(controller.canExecute());
+         Result result = controller.execute();
+         Assert.assertFalse(result instanceof Failed);
+         Assert.assertEquals("Field customerType created", result.getMessage());
+      }
+
+      JavaClass<?> javaClass = entity.getJavaType();
+      Assert.assertTrue(javaClass.hasField("customerType"));
+      final Field<?> field = javaClass.getField("customerType");
+      Assert.assertEquals("CustomerType", field.getType().getName());
+      Assert.assertFalse(field.hasAnnotation(Column.class));
+      Assert.assertTrue(field.hasAnnotation(Enumerated.class));
+      Assert.assertFalse(field.getAnnotation(Enumerated.class).getValues().isEmpty());
+      Assert.assertEquals(EnumType.STRING, field.getAnnotation(Enumerated.class).getEnumValue(EnumType.class));
+   }
+
+
 
 }

--- a/parser-java/api/src/main/java/org/jboss/forge/addon/parser/java/beans/FieldOperations.java
+++ b/parser-java/api/src/main/java/org/jboss/forge/addon/parser/java/beans/FieldOperations.java
@@ -7,9 +7,15 @@
 
 package org.jboss.forge.addon.parser.java.beans;
 
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jboss.forge.addon.parser.java.facets.JavaSourceFacet;
+import org.jboss.forge.addon.parser.java.resources.JavaResource;
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.resource.ResourceException;
+import org.jboss.forge.furnace.util.Assert;
 import org.jboss.forge.roaster.model.Field;
 import org.jboss.forge.roaster.model.Visibility;
 import org.jboss.forge.roaster.model.source.FieldSource;
@@ -126,5 +132,56 @@ public class FieldOperations
    protected boolean canAddFieldToToString(Field<JavaClassSource> field)
    {
       return !field.isStatic();
+   }
+
+   /**
+    * @param project   Project in which the fieldType will be searched
+    * @param fieldType Full type of the field with package
+    * @return true if fieldType was found and is enum
+    *         false otherwise.
+    * @throws IllegalArgumentException if fieldType or project is null
+    */
+   public boolean isFieldTypeEnum(Project project, String fieldType)
+   {
+      return isFieldTypeEnum(project, null, fieldType);
+   }
+
+   /**
+    * @param project      Project in which the fieldType will be searched
+    * @param fieldType    Type of the field
+    * @param targetEntity Entity which package which will be used if fieldType doesn't have package specified
+    * @return true if fieldType was found and is enum
+    *         false otherwise.
+    * @throws IllegalArgumentException if fieldType or project is null
+    */
+   public boolean isFieldTypeEnum(Project project, JavaClassSource targetEntity, String fieldType)
+   {
+      boolean isEnum = false;
+
+      Assert.notNull(fieldType, "Field type should not be null");
+      Assert.notNull(project, "Field project should not be null");
+
+      try
+      {
+         isEnum = project.getFacet(JavaSourceFacet.class).getJavaResource(fieldType).getJavaType().isEnum();
+      }
+      catch (FileNotFoundException | ResourceException e1)
+      {
+         try
+         {
+            if (targetEntity != null)
+            {
+
+               isEnum = project.getFacet(JavaSourceFacet.class)
+                        .getJavaResource(targetEntity.getPackage() + "." + fieldType).getJavaType().isEnum();
+            }
+         }
+         catch (FileNotFoundException | ResourceException e2)
+         {
+            // ignore
+         }
+      }
+
+      return isEnum;
    }
 }


### PR DESCRIPTION
Hi, I've tried to implement FORGE-1450. I'would be really glad for any feedback. Thank you very much.

When adding new field to entity, it will detect if type of field is enum and will set correct annotations.
New attribute added "--enumType". "--columnName" is also supported.
Enums are also added to auto-complete feature.

 Usage:
1.

```
jpa-new-field --named myCustomEnum --typeName sample.CustomEnumType
```

Output:

```
@Enumerated
private CustomEnumType myCustomEnum
```

2.

```
jpa-new-field --named myCustomEnum --typeName sample.CustomEnumType --enumType STRING
```

Output:

```
@Enumerated(EnumType.STRING)
private CustomEnumType myCustomEnum
```

3.

```
jpa-new-field --type PersonType --columnName "ENUM_COLUMN"
```

Output:

```
@Enumerated
@Column(name = "ENUM_COLUMN")
private CustomEnumType myCustomEnum
```
