### PR TITLE
Fix ProjectFactoryImpl.findProject() bug

### DIFF
--- a/projects/impl/src/main/java/org/jboss/forge/addon/projects/impl/ProjectFactoryImpl.java
+++ b/projects/impl/src/main/java/org/jboss/forge/addon/projects/impl/ProjectFactoryImpl.java
@@ -128,6 +128,9 @@ public class ProjectFactoryImpl implements ProjectFactory
          for (ProjectProvider projectProvider : getProviders())
          {
             result = findProjectInDirectory(dir, projectProvider, filter);
+
+            if (result != null)
+               break;
          }
 
          if (result != null)


### PR DESCRIPTION
This caused gradle addon tests fail with 50% chance if this method was used.
