### PR TITLE
Make sure that scaffolded ManyToOne relationships without one part do no...

### DIFF
--- a/javaee/faces/src/main/java/org/jboss/forge/addon/scaffold/faces/metawidget/widgetbuilder/EntityWidgetBuilder.java
+++ b/javaee/faces/src/main/java/org/jboss/forge/addon/scaffold/faces/metawidget/widgetbuilder/EntityWidgetBuilder.java
@@ -158,6 +158,8 @@ public class EntityWidgetBuilder
                         (StaticUIMetawidget) metawidget);
             }
 
+            link.putAttribute("rendered", StaticFacesUtils.wrapExpression("!empty " + StaticFacesUtils.unwrapExpression(link.getValue())));
+
             String reverseKey = "id";
             if (attributes.containsKey(REVERSE_PRIMARY_KEY))
             {


### PR DESCRIPTION
...t throw NullPointerException upon rendering

Tested on WildFly 8. Without the change I got the exception. With the change, the customer without parent renders correctly
