### PR TITLE
Rely on TomEE to supply defaults

### DIFF
--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/containers/TomEEContainer.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/jpa/containers/TomEEContainer.java
@@ -10,18 +10,20 @@ import org.jboss.forge.addon.javaee.jpa.DatabaseType;
 
 public class TomEEContainer extends JavaEEDefaultContainer
 {
-   private static final String DEFAULT_DATASOURCE_NAME = "Default JDBC Database";
 
+   /**
+    * When you do not specify a jta-data-source and non-jta-data-source,
+    * TomEE will automatically look for a suitable DataSource from the
+    * tomee.xml config.  The matching is quite intelligent and will start
+    * with the persistence unit name, but also try the webapp name and
+    * even the ear name if applicable.
+    * 
+    * If one is not found, defaults are created.
+    */
    @Override
-   public DatabaseType getDefaultDatabaseType()
+   public boolean isDataSourceRequired()
    {
-      return DatabaseType.HSQLDB;
-   }
-
-   @Override
-   public String getDefaultDataSource()
-   {
-      return DEFAULT_DATASOURCE_NAME;
+      return false;
    }
 
    @Override


### PR DESCRIPTION
I didn't run or compile this.  Fixing after helping Ivan out with some issues related to this "non TomEE supplied" default.  Hopefully documented enough so that if this code doesn't work, the right path is clear (don't specify <jta-data-source> or <non-jta-data-source>)
