### PR TITLE
FORGE-1546 Entity fields larger than 800 symbols  should generate textarea

### DIFF
--- a/javaee/faces/src/main/java/org/jboss/forge/addon/scaffold/faces/metawidget/inspector/ForgeInspector.java
+++ b/javaee/faces/src/main/java/org/jboss/forge/addon/scaffold/faces/metawidget/inspector/ForgeInspector.java
@@ -18,6 +18,7 @@ import static org.jboss.forge.addon.scaffold.faces.metawidget.inspector.ForgeIns
 import static org.jboss.forge.addon.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.OWNING_FIELD;
 import static org.jboss.forge.addon.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.PRIMARY_KEY;
 import static org.jboss.forge.addon.scaffold.faces.metawidget.inspector.ForgeInspectionResultConstants.REVERSE_PRIMARY_KEY;
+import static org.metawidget.inspector.InspectionResultConstants.LARGE;
 import static org.metawidget.inspector.InspectionResultConstants.LOOKUP;
 import static org.metawidget.inspector.InspectionResultConstants.TRUE;
 import static org.metawidget.inspector.faces.StaticFacesInspectionResultConstants.FACES_CONVERTER_ID;
@@ -26,6 +27,7 @@ import static org.metawidget.inspector.faces.StaticFacesInspectionResultConstant
 import java.util.List;
 import java.util.Map;
 
+import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -53,6 +55,7 @@ import org.w3c.dom.Element;
 public class ForgeInspector
          extends BaseObjectInspector
 {
+   public static final int TEXT_AREA_GENERATION_LENGTH = 800;
 
    //
    // Constructor
@@ -179,6 +182,15 @@ public class ForgeInspector
          attributes.put(GENERATED_VALUE, TRUE);
       }
 
+      // Large inputs
+      if (property.isAnnotationPresent(Column.class))
+      {
+         Column annotation = property.getAnnotation(Column.class);
+         if (annotation.length() >= TEXT_AREA_GENERATION_LENGTH)
+         {
+            attributes.put(LARGE, TRUE);
+         }
+      }
       return attributes;
    }
 

--- a/javaee/faces/src/main/java/org/jboss/forge/addon/scaffold/faces/metawidget/widgetbuilder/EntityWidgetBuilder.java
+++ b/javaee/faces/src/main/java/org/jboss/forge/addon/scaffold/faces/metawidget/widgetbuilder/EntityWidgetBuilder.java
@@ -17,6 +17,7 @@ import static org.metawidget.inspector.InspectionResultConstants.PARAMETERIZED_T
 import static org.metawidget.inspector.InspectionResultConstants.REQUIRED;
 import static org.metawidget.inspector.InspectionResultConstants.TRUE;
 import static org.metawidget.inspector.InspectionResultConstants.TYPE;
+import static org.metawidget.inspector.InspectionResultConstants.LARGE;
 import static org.metawidget.inspector.faces.StaticFacesInspectionResultConstants.FACES_CONVERTER_ID;
 import static org.metawidget.inspector.faces.StaticFacesInspectionResultConstants.FACES_LOOKUP;
 
@@ -44,6 +45,7 @@ import org.metawidget.statically.faces.component.html.widgetbuilder.Facet;
 import org.metawidget.statically.faces.component.html.widgetbuilder.HtmlColumn;
 import org.metawidget.statically.faces.component.html.widgetbuilder.HtmlCommandLink;
 import org.metawidget.statically.faces.component.html.widgetbuilder.HtmlDataTable;
+import org.metawidget.statically.faces.component.html.widgetbuilder.HtmlInputTextarea;
 import org.metawidget.statically.faces.component.html.widgetbuilder.HtmlOutcomeTargetLink;
 import org.metawidget.statically.faces.component.html.widgetbuilder.HtmlOutputText;
 import org.metawidget.statically.faces.component.html.widgetbuilder.HtmlSelectOneMenu;
@@ -62,6 +64,7 @@ import org.metawidget.util.XmlUtils;
 import org.metawidget.util.simple.StringUtils;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
 
 /**
  * Builds widgets with Forge-specific behaviours (such as links to other scaffolding pages).
@@ -271,6 +274,13 @@ public class EntityWidgetBuilder
             if (Collection.class.isAssignableFrom(clazz))
             {
                return createDataTableComponent(elementName, attributes, metawidget);
+            }
+            else if (String.class.equals(clazz))
+            {
+               if (TRUE.equals(attributes.get(LARGE)))
+               {
+                  return new HtmlInputTextarea();
+               }
             }
          }
       }

--- a/scaffold/spi/src/main/java/org/jboss/forge/addon/scaffold/metawidget/inspector/ForgeInspector.java
+++ b/scaffold/spi/src/main/java/org/jboss/forge/addon/scaffold/metawidget/inspector/ForgeInspector.java
@@ -20,11 +20,14 @@ import static org.jboss.forge.addon.scaffold.metawidget.inspector.ForgeInspectio
 import static org.jboss.forge.addon.scaffold.metawidget.inspector.ForgeInspectionResultConstants.OWNING_FIELD;
 import static org.jboss.forge.addon.scaffold.metawidget.inspector.ForgeInspectionResultConstants.PRIMARY_KEY;
 import static org.jboss.forge.addon.scaffold.metawidget.inspector.ForgeInspectionResultConstants.REVERSE_PRIMARY_KEY;
+import static org.metawidget.inspector.InspectionResultConstants.LARGE;
+import static org.metawidget.inspector.InspectionResultConstants.TRUE;
 
 import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.Map;
 
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
 import javax.persistence.GeneratedValue;
@@ -56,6 +59,8 @@ import org.w3c.dom.Element;
 public class ForgeInspector
          extends BaseObjectInspector
 {
+   public static final int TEXT_AREA_GENERATION_LENGTH = 800;
+
    private Project project;
    private JavaSourceFacet java;
 
@@ -111,7 +116,7 @@ public class ForgeInspector
 
       if (property.isAnnotationPresent(OneToOne.class))
       {
-         attributes.put(ONE_TO_ONE, InspectionResultConstants.TRUE);
+         attributes.put(ONE_TO_ONE, TRUE);
          attributes.put(JPA_REL_TYPE, JPA_ONE_TO_ONE);
          getReversePrimaryKey(property, attributes);
          if (property.isAnnotationPresent(OneToOne.class))
@@ -122,7 +127,7 @@ public class ForgeInspector
 
       if (property.isAnnotationPresent(Embedded.class) || isPropertyTypeEmbeddedable(property.getType()))
       {
-         attributes.put(EMBEDDABLE, InspectionResultConstants.TRUE);
+         attributes.put(EMBEDDABLE, TRUE);
       }
 
       // ManyToOne
@@ -130,7 +135,7 @@ public class ForgeInspector
       if (property.isAnnotationPresent(ManyToOne.class))
       {
          attributes.put(JPA_REL_TYPE, JPA_MANY_TO_ONE);
-         attributes.put(MANY_TO_ONE, InspectionResultConstants.TRUE);
+         attributes.put(MANY_TO_ONE, TRUE);
          getReversePrimaryKey(property, attributes);
          getManyToOneBidirectionalProperties(property, attributes);
       }
@@ -139,7 +144,7 @@ public class ForgeInspector
 
       if (property.isAnnotationPresent(OneToMany.class) || property.isAnnotationPresent(ManyToMany.class))
       {
-         attributes.put(N_TO_MANY, InspectionResultConstants.TRUE);
+         attributes.put(N_TO_MANY, TRUE);
          getCollectionReversePrimaryKey(property, attributes);
          if (property.isAnnotationPresent(OneToMany.class))
          {
@@ -176,11 +181,21 @@ public class ForgeInspector
 
       if (property.isAnnotationPresent(Id.class))
       {
-         attributes.put(PRIMARY_KEY, InspectionResultConstants.TRUE);
+         attributes.put(PRIMARY_KEY, TRUE);
       }
       if (property.isAnnotationPresent(GeneratedValue.class))
       {
-         attributes.put(GENERATED_VALUE, InspectionResultConstants.TRUE);
+         attributes.put(GENERATED_VALUE, TRUE);
+      }
+
+      // Large inputs
+      if (property.isAnnotationPresent(Column.class))
+      {
+         Column annotation = property.getAnnotation(Column.class);
+         if (annotation.length() >= TEXT_AREA_GENERATION_LENGTH)
+         {
+            attributes.put(LARGE, TRUE);
+         }
       }
 
       return attributes;


### PR DESCRIPTION
After executing the following commands:
project-new --named demo
jpa-new-entity --named Person
jpa-new-field --named name --type String --length 100
jpa-new-field --named bio --type String --length 900
jpa-new-field --named age --type int

The following facelet was generated:
https://gist.github.com/ivannov/2b02de01486f0b9c2682

And it looks like this:
http://tinypic.com/r/2mzwf7q/8
