### PR TITLE
FORGE-1880 - Created command which adds annotation to class, field or method

### DIFF
--- a/parser-java/api/src/main/java/org/jboss/forge/addon/parser/java/beans/ProjectOperations.java
+++ b/parser-java/api/src/main/java/org/jboss/forge/addon/parser/java/beans/ProjectOperations.java
@@ -25,7 +25,17 @@ public class ProjectOperations
       }
       return classes;
    }
-   
+
+   public List<JavaResource> getProjectAnnotations(Project project)
+   {
+      final List<JavaResource> classes = new ArrayList<>();
+      if (project != null)
+      {
+         project.getFacet(JavaSourceFacet.class).visitJavaSources(new JavaAnnotationsSourceVisitor(classes));
+      }
+      return classes;
+   }
+
    private static class JavaClassSourceVisitor extends JavaResourceVisitor
    {
       private final List<JavaResource> classes;
@@ -42,6 +52,33 @@ public class ProjectOperations
          {
             JavaSource<?> javaType = resource.getJavaType();
             if (javaType.isClass())
+            {
+               classes.add(resource);
+            }
+         }
+         catch (FileNotFoundException e)
+         {
+            // ignore
+         }
+      }
+   }
+
+   private static class JavaAnnotationsSourceVisitor extends JavaResourceVisitor
+   {
+      private final List<JavaResource> classes;
+
+      private JavaAnnotationsSourceVisitor(List<JavaResource> classes)
+      {
+         this.classes = classes;
+      }
+
+      @Override
+      public void visit(VisitContext context, JavaResource resource)
+      {
+         try
+         {
+            JavaSource<?> javaType = resource.getJavaType();
+            if (javaType.isAnnotation())
             {
                classes.add(resource);
             }

--- a/parser-java/api/src/main/java/org/jboss/forge/addon/parser/java/ui/annotations/JavaAddAnnotationCommand.java
+++ b/parser-java/api/src/main/java/org/jboss/forge/addon/parser/java/ui/annotations/JavaAddAnnotationCommand.java
@@ -1,0 +1,7 @@
+package org.jboss.forge.addon.parser.java.ui.annotations;
+
+import org.jboss.forge.addon.ui.command.UICommand;
+
+public interface JavaAddAnnotationCommand extends UICommand
+{
+}

--- a/parser-java/impl/src/main/java/org/jboss/forge/addon/parser/java/ui/annotations/JavaAddAnnotationCommandImpl.java
+++ b/parser-java/impl/src/main/java/org/jboss/forge/addon/parser/java/ui/annotations/JavaAddAnnotationCommandImpl.java
@@ -1,0 +1,321 @@
+package org.jboss.forge.addon.parser.java.ui.annotations;
+
+import org.jboss.forge.addon.convert.Converter;
+import org.jboss.forge.addon.parser.java.beans.ProjectOperations;
+import org.jboss.forge.addon.parser.java.facets.JavaSourceFacet;
+import org.jboss.forge.addon.parser.java.resources.JavaFieldResource;
+import org.jboss.forge.addon.parser.java.resources.JavaMethodResource;
+import org.jboss.forge.addon.parser.java.resources.JavaResource;
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.projects.ProjectFactory;
+import org.jboss.forge.addon.projects.ui.AbstractProjectCommand;
+import org.jboss.forge.addon.resource.FileResource;
+import org.jboss.forge.addon.resource.ResourceException;
+import org.jboss.forge.addon.resource.util.ResourceUtil;
+import org.jboss.forge.addon.ui.context.UIBuilder;
+import org.jboss.forge.addon.ui.context.UIContext;
+import org.jboss.forge.addon.ui.context.UIExecutionContext;
+import org.jboss.forge.addon.ui.context.UISelection;
+import org.jboss.forge.addon.ui.hints.InputType;
+import org.jboss.forge.addon.ui.input.InputComponent;
+import org.jboss.forge.addon.ui.input.UICompleter;
+import org.jboss.forge.addon.ui.input.UIInput;
+import org.jboss.forge.addon.ui.input.UISelectOne;
+import org.jboss.forge.addon.ui.metadata.UICommandMetadata;
+import org.jboss.forge.addon.ui.metadata.WithAttributes;
+import org.jboss.forge.addon.ui.result.Result;
+import org.jboss.forge.addon.ui.result.Results;
+import org.jboss.forge.addon.ui.util.Categories;
+import org.jboss.forge.addon.ui.util.Metadata;
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.Annotation;
+import org.jboss.forge.roaster.model.JavaClass;
+import org.jboss.forge.roaster.model.Parameter;
+import org.jboss.forge.roaster.model.ValuePair;
+import org.jboss.forge.roaster.model.source.*;
+
+import javax.inject.Inject;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * @author <a href="mailto:robert@balent.cz">Robert Balent</a>
+ */
+public class JavaAddAnnotationCommandImpl extends AbstractProjectCommand implements JavaAddAnnotationCommand
+{
+   @Inject
+   @WithAttributes(label = "Target Class", description = "The class where the annotation will be added", required = true, type = InputType.DROPDOWN)
+   private UISelectOne<JavaResource> targetClass;
+
+   @Inject
+   @WithAttributes(label = "Annotation", description = "The annotation which will be added", required = true, type = InputType.DEFAULT)
+   private UIInput<String> annotation;
+
+   @Inject
+   @WithAttributes(label = "Target property", description = "The property where the annotation will be added", required = false, type = InputType.DROPDOWN)
+   private UISelectOne<JavaFieldResource> onProperty;
+
+   @Inject
+   @WithAttributes(label = "Target property", description = "The method where the annotation will be added", required = false, type = InputType.DROPDOWN)
+   private UISelectOne<JavaMethodResource> onMethod;
+
+   @Inject
+   private ProjectOperations projectOperations;
+
+   @Override
+   public UICommandMetadata getMetadata(UIContext context)
+   {
+      return Metadata.forCommand(getClass()).name("Java: Add Annotation")
+               .description("Add annotation to class, property or method.")
+               .category(Categories.create("Java"));
+   }
+
+   @Override
+   public void initializeUI(final UIBuilder builder)
+   {
+      setupTargetClass(builder.getUIContext());
+
+      onProperty.setEnabled(new Callable<Boolean>()
+      {
+         @Override
+         public Boolean call()
+         {
+            if (onMethod.getValue() != null || onProperty.getValue() != null)
+            {
+               return false;
+            }
+
+            JavaResource javaResource = targetClass.getValue();
+
+            if (javaResource != null)
+            {
+               return ResourceUtil.filterByType(JavaFieldResource.class, javaResource.listResources()).size() > 0;
+            }
+            return false;
+         }
+      });
+
+      onMethod.setEnabled(new Callable<Boolean>()
+      {
+         @Override
+         public Boolean call()
+         {
+            if (onMethod.getValue() != null || onProperty.getValue() != null)
+            {
+               return false;
+            }
+
+            JavaResource javaResource = targetClass.getValue();
+
+            if (javaResource != null)
+            {
+               return ResourceUtil.filterByType(JavaMethodResource.class, javaResource.listResources()).size() > 0;
+            }
+            return false;
+         }
+      });
+
+      onProperty.setValueChoices(new Callable<Iterable<JavaFieldResource>>()
+      {
+         @Override
+         public Iterable<JavaFieldResource> call()
+         {
+            JavaResource javaResource = targetClass.getValue();
+            return ResourceUtil.filterByType(JavaFieldResource.class, javaResource.listResources());
+         }
+      });
+
+      onMethod.setValueChoices(new Callable<Iterable<JavaMethodResource>>()
+      {
+         @Override
+         public Iterable<JavaMethodResource> call()
+         {
+            JavaResource javaResource = targetClass.getValue();
+            return ResourceUtil.filterByType(JavaMethodResource.class, javaResource.listResources());
+         }
+      });
+
+      onProperty.setItemLabelConverter(new Converter<JavaFieldResource, String>()
+      {
+         @Override
+         public String convert(JavaFieldResource source)
+         {
+            return source.getUnderlyingResourceObject().getName();
+         }
+      });
+
+      onMethod.setItemLabelConverter(new Converter<JavaMethodResource, String>()
+      {
+         @Override
+         public String convert(JavaMethodResource source)
+         {
+            return source.getUnderlyingResourceObject().getName();
+         }
+      });
+
+      annotation.setCompleter(new UICompleter<String>()
+      {
+         @Override public Iterable<String> getCompletionProposals(UIContext context, InputComponent<?, String> input, String value)
+         {
+            Project project = getSelectedProject(builder.getUIContext());
+            List<JavaResource> javaClasses = projectOperations.getProjectAnnotations(project);
+            List<String> projectAnnotations = new ArrayList<>();
+            for (JavaResource javaResource : javaClasses)
+            {
+               try
+               {
+                  projectAnnotations.add(javaResource.getJavaType().getCanonicalName());
+               }
+               catch (FileNotFoundException | ResourceException ignored)
+               {
+                  // don't mind
+               }
+            }
+            return projectAnnotations;
+         }
+      });
+
+      builder.add(targetClass).add(annotation).add(onProperty).add(onMethod);
+   }
+
+   @Override
+   public Result execute(UIExecutionContext context) throws Exception
+   {
+      JavaClassSource javaSource = targetClass.getValue().getJavaType();
+
+      Result result;
+
+      if (onProperty.hasValue())
+      {
+         String propertyName = onProperty.getValue().getUnderlyingResourceObject().getName();
+         AnnotationTargetSource field = javaSource.getField(propertyName);
+
+         addAnnotationToSource(field, annotation.getValue());
+
+         result = Results.success("Annotation \"" + annotation.getValue() + "\" was successfully added to \""
+                  + propertyName + "\" property declaration.");
+      }
+      else if (onMethod.hasValue())
+      {
+         List<Parameter> parameters = onMethod.getValue().getUnderlyingResourceObject().getParameters();
+
+         String[] stringParametersArray = new String[parameters.size()];
+
+         for (int i = 0; i < parameters.size(); i++)
+         {
+            stringParametersArray[i] = parameters.get(i).getType().getName();
+         }
+
+         String methodName = onMethod.getValue().getUnderlyingResourceObject().getName();
+         AnnotationTargetSource method = javaSource.getMethod(methodName, stringParametersArray);
+
+         addAnnotationToSource(method, annotation.getValue());
+
+         result = Results.success("Annotation \"" + annotation.getValue() + "\" was successfully added to the \""
+                  + methodName + "\" method declaration.");
+      }
+      else
+      {
+         addAnnotationToSource(javaSource, annotation.getValue());
+
+         result = Results.success("Annotation \"" + annotation.getValue()
+                  + "\" was successfully added to the class declaration.");
+      }
+
+      getSelectedProject(context).getFacet(JavaSourceFacet.class).saveJavaSource(javaSource);
+
+      return result;
+   }
+
+   private void addAnnotationToSource(AnnotationTargetSource targetSource, String annotationStr)
+   {
+      String annotationClassName = getAnnotationClassNameFromString(annotationStr);
+
+      AnnotationSource<JavaClassSource> annotationToRemove = targetSource.getAnnotation(annotationClassName);
+
+      if (annotationToRemove != null)
+      {
+         targetSource.removeAnnotation(annotationToRemove);
+      }
+
+      AnnotationSource<JavaClassSource> annotationSource;
+
+      try
+      {
+         annotationSource = targetSource.addAnnotation(annotationClassName);
+      }
+      catch (Exception ex)
+      {
+         throw new IllegalArgumentException("Annotation with name \"" + annotationClassName + "\" couldn't be added. Are you sure it's correct?");
+      }
+
+      populateAnnotationFromString(annotationSource, annotation.getValue());
+   }
+
+   private void populateAnnotationFromString(AnnotationSource<JavaClassSource> annotationSource, String str)
+   {
+      String stub = "@" + str + " public class Stub { }";
+      JavaClass<?> parsedClass;
+      try
+      {
+         parsedClass = Roaster.parse(JavaClass.class, stub);
+      }
+      catch (Exception ex)
+      {
+         throw new IllegalArgumentException("Can't parse annotation \"" + str + "\". Are you sure it's correct?");
+      }
+
+      if (parsedClass.getAnnotations().size() == 0) {
+         throw new IllegalArgumentException("Can't parse annotation \"" + str + "\". Are you sure it's correct?");
+      }
+
+      List<ValuePair> valuePairs = parsedClass.getAnnotations().get(0).getValues();
+
+      for (ValuePair valuePair : valuePairs) {
+         if ("$missing$".equals(valuePair.getLiteralValue())) {
+            throw new IllegalArgumentException("Parameter \"" + valuePair.getName() + "\" is missing or is incomplete.");
+         }
+         annotationSource.setLiteralValue(valuePair.getName(), valuePair.getLiteralValue());
+      }
+   }
+
+   private String getAnnotationClassNameFromString(String annotationString) {
+      int leftParenthesisIndex = annotationString.indexOf('(');
+      if (leftParenthesisIndex > -1) {
+         return annotationString.substring(0, leftParenthesisIndex);
+      }
+      return annotationString;
+   }
+
+   private void setupTargetClass(UIContext context)
+   {
+      UISelection<FileResource<?>> selection = context.getInitialSelection();
+      Project project = getSelectedProject(context);
+      final List<JavaResource> entities = projectOperations.getProjectClasses(project);
+      targetClass.setValueChoices(entities);
+      int idx = -1;
+      if (!selection.isEmpty())
+      {
+         idx = entities.indexOf(selection.get());
+      }
+      if (idx != -1)
+      {
+         targetClass.setDefaultValue(entities.get(idx));
+      }
+   }
+
+   @Override protected boolean isProjectRequired()
+   {
+      return true;
+   }
+
+   @Inject
+   private ProjectFactory projectFactory;
+
+   @Override protected ProjectFactory getProjectFactory()
+   {
+      return projectFactory;
+   }
+}

--- a/parser-java/tests/src/test/java/org/jboss/forge/addon/parser/java/ui/JavaAddAnnotationCommandTest.java
+++ b/parser-java/tests/src/test/java/org/jboss/forge/addon/parser/java/ui/JavaAddAnnotationCommandTest.java
@@ -1,0 +1,368 @@
+package org.jboss.forge.addon.parser.java.ui;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.addon.facets.FacetFactory;
+import org.jboss.forge.addon.parser.java.facets.JavaSourceFacet;
+import org.jboss.forge.addon.parser.java.ui.annotations.JavaAddAnnotationCommand;
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.projects.ProjectFactory;
+import org.jboss.forge.addon.ui.controller.CommandController;
+import org.jboss.forge.addon.ui.test.UITestHarness;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.Dependencies;
+import org.jboss.forge.arquillian.archive.ForgeArchive;
+import org.jboss.forge.furnace.repositories.AddonDependencyEntry;
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.source.AnnotationSource;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import java.io.FileNotFoundException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Testing {@link org.jboss.forge.addon.parser.java.ui.annotations.JavaAddAnnotationCommand} class.
+ * Use cases:
+ * 1. Adding annotation on class
+ * 2. Adding annotation on property
+ * 3. Adding annotation on method
+ * 4. Adding same annotation more than once - should be overwritten
+ *
+ * @author <a href="mailto:robert@balent.cz">Robert Balent</a>
+ */
+@RunWith(Arquillian.class)
+public class JavaAddAnnotationCommandTest
+{
+   private static final String TEST_CLASS_STRING = "public class Person { "
+            + "private String name; "
+            + "public String getName() { return name; } "
+            + "public void setName(String name) { this.name = name; } "
+            + "}";
+   @Inject
+   private ProjectFactory projectFactory;
+   @Inject
+   private UITestHarness testHarness;
+   @Inject
+   private FacetFactory facetFactory;
+   private Project project;
+   private JavaClassSource targetClass;
+   private CommandController commandController;
+
+   @Deployment
+   @Dependencies({
+            @AddonDependency(name = "org.jboss.forge.addon:parser-java"),
+            @AddonDependency(name = "org.jboss.forge.addon:ui-test-harness"),
+            @AddonDependency(name = "org.jboss.forge.addon:projects"),
+            @AddonDependency(name = "org.jboss.forge.addon:maven"),
+            @AddonDependency(name = "org.jboss.forge.furnace.container:cdi")
+   })
+   public static ForgeArchive getDeployment()
+   {
+      return ShrinkWrap
+               .create(ForgeArchive.class)
+               .addBeansXML()
+               .addAsAddonDependencies(
+                        AddonDependencyEntry.create("org.jboss.forge.furnace.container:cdi"),
+                        AddonDependencyEntry.create("org.jboss.forge.addon:projects"),
+                        AddonDependencyEntry.create("org.jboss.forge.addon:parser-java"),
+                        AddonDependencyEntry.create("org.jboss.forge.addon:ui-test-harness"),
+                        AddonDependencyEntry.create("org.jboss.forge.addon:maven"),
+                        AddonDependencyEntry.create("org.jboss.forge.addon:ui-test-harness")
+               );
+   }
+
+   @Before
+   public void setup() throws Exception
+   {
+      createTempProject();
+
+   }
+
+   @Test
+   public void testAddAnnotationOnClass() throws Exception
+   {
+      createTargetClass(TEST_CLASS_STRING);
+      createCommandController();
+      commandController.initialize();
+      commandController.setValueFor("annotation", "javax.persistence.Entity");
+      commandController.execute();
+      reloadTargetClass();
+
+      List<AnnotationSource<JavaClassSource>> classAnnotations = targetClass.getAnnotations();
+      assertEquals(1, classAnnotations.size());
+      assertEquals("Entity", classAnnotations.get(0).getName());
+
+      assertEquals(0, targetClass.getField("name").getAnnotations().size());
+      assertEquals(0, targetClass.getMethod("getName").getAnnotations().size());
+      assertEquals(0, targetClass.getMethod("setName", "String").getAnnotations().size());
+   }
+
+   @Test
+   public void testAddAnnotationOnProperty() throws Exception
+   {
+      createTargetClass(TEST_CLASS_STRING);
+      createCommandController();
+      commandController.initialize();
+      commandController.setValueFor("annotation", "javax.persistence.Column");
+      commandController.setValueFor("onProperty", "name");
+      commandController.execute();
+      reloadTargetClass();
+
+      List<AnnotationSource<JavaClassSource>> fieldAnnotations = targetClass.getField("name").getAnnotations();
+      assertEquals(1, fieldAnnotations.size());
+      assertEquals("Column", fieldAnnotations.get(0).getName());
+
+      assertEquals(0, targetClass.getAnnotations().size());
+      assertEquals(0, targetClass.getMethod("getName").getAnnotations().size());
+      assertEquals(0, targetClass.getMethod("setName", "String").getAnnotations().size());
+   }
+
+   @Test
+   public void testAddAnnotationOnMethod() throws Exception
+   {
+      createTargetClass(TEST_CLASS_STRING);
+      createCommandController();
+      commandController.initialize();
+      commandController.setValueFor("annotation", "javax.persistence.Column");
+      commandController.setValueFor("onMethod", "getName");
+      commandController.execute();
+      reloadTargetClass();
+
+      List<AnnotationSource<JavaClassSource>> methodAnnotations = targetClass.getMethod("getName").getAnnotations();
+      assertEquals(1, methodAnnotations.size());
+      assertEquals("Column", methodAnnotations.get(0).getName());
+
+      assertEquals(0, targetClass.getAnnotations().size());
+      assertEquals(0, targetClass.getField("name").getAnnotations().size());
+      assertEquals(0, targetClass.getMethod("setName", "String").getAnnotations().size());
+   }
+
+   @Test
+   public void testAddAnnotationOnClassThreeTimes() throws Exception
+   {
+      createTargetClass(TEST_CLASS_STRING);
+      createCommandController();
+      commandController.initialize();
+      commandController.setValueFor("annotation", "javax.persistence.Entity");
+      commandController.execute();
+      reloadTargetClass();
+      createCommandController();
+      commandController.initialize();
+      commandController.setValueFor("annotation", "javax.persistence.Entity");
+      commandController.execute();
+      reloadTargetClass();
+      createCommandController();
+      commandController.initialize();
+      commandController.setValueFor("annotation", "Entity");
+      commandController.execute();
+      reloadTargetClass();
+
+      List<AnnotationSource<JavaClassSource>> classAnnotations = targetClass.getAnnotations();
+      assertEquals(1, classAnnotations.size());
+      assertEquals("Entity", classAnnotations.get(0).getName());
+
+      assertEquals(0, targetClass.getField("name").getAnnotations().size());
+      assertEquals(0, targetClass.getMethod("getName").getAnnotations().size());
+      assertEquals(0, targetClass.getMethod("setName", "String").getAnnotations().size());
+   }
+
+   @Test
+   public void testAddAnnotationOnPropertyThreeTimes() throws Exception
+   {
+      createTargetClass(TEST_CLASS_STRING);
+      createCommandController();
+      commandController.initialize();
+      commandController.setValueFor("annotation", "javax.persistence.Column");
+      commandController.setValueFor("onProperty", "name");
+      commandController.execute();
+      reloadTargetClass();
+      createCommandController();
+      commandController.initialize();
+      commandController.setValueFor("annotation", "javax.persistence.Column");
+      commandController.setValueFor("onProperty", "name");
+      commandController.execute();
+      reloadTargetClass();
+      createCommandController();
+      commandController.initialize();
+      commandController.setValueFor("annotation", "Column");
+      commandController.setValueFor("onProperty", "name");
+      commandController.execute();
+      reloadTargetClass();
+
+      List<AnnotationSource<JavaClassSource>> fieldAnnotations = targetClass.getField("name").getAnnotations();
+      assertEquals(1, fieldAnnotations.size());
+      assertEquals("Column", fieldAnnotations.get(0).getName());
+
+      assertEquals(0, targetClass.getAnnotations().size());
+      assertEquals(0, targetClass.getMethod("getName").getAnnotations().size());
+      assertEquals(0, targetClass.getMethod("setName", "String").getAnnotations().size());
+   }
+
+   @Test
+   public void testAddAnnotationOnMethodThreeTimes() throws Exception
+   {
+      createTargetClass(TEST_CLASS_STRING);
+      createCommandController();
+      commandController.initialize();
+      commandController.setValueFor("annotation", "javax.persistence.Column");
+      commandController.setValueFor("onMethod", "getName");
+      commandController.execute();
+      reloadTargetClass();
+      createCommandController();
+      commandController.initialize();
+      commandController.setValueFor("annotation", "javax.persistence.Column");
+      commandController.setValueFor("onMethod", "getName");
+      commandController.execute();
+      reloadTargetClass();
+      createCommandController();
+      commandController.initialize();
+      commandController.setValueFor("annotation", "Column");
+      commandController.setValueFor("onMethod", "getName");
+      commandController.execute();
+      reloadTargetClass();
+
+      List<AnnotationSource<JavaClassSource>> methodAnnotations = targetClass.getMethod("getName").getAnnotations();
+      assertEquals(1, methodAnnotations.size());
+      assertEquals("Column", methodAnnotations.get(0).getName());
+
+      assertEquals(0, targetClass.getAnnotations().size());
+      assertEquals(0, targetClass.getField("name").getAnnotations().size());
+      assertEquals(0, targetClass.getMethod("setName", "String").getAnnotations().size());
+   }
+
+   @Test
+   public void testAddComplexAnnotation() throws Exception
+   {
+      createTargetClass(TEST_CLASS_STRING);
+      createCommandController();
+      commandController.initialize();
+
+      String complexAnnotation = "TestAnnotation(" +
+               "param1 = {\"str1\", \"str2\"}, " +
+               "param2 = \"hello\", " +
+               "param3 = {String.class, Main.class}, " +
+               "param4 = ENUM_VAL, " +
+               "param5 = {ENUM_VAL_1,ENUM_VAL_2,ENUM_VAL_3}" +
+               ")";
+
+      commandController.setValueFor("annotation", complexAnnotation);
+      commandController.execute();
+      reloadTargetClass();
+
+      List<AnnotationSource<JavaClassSource>> classAnnotations = targetClass.getAnnotations();
+      assertEquals(1, classAnnotations.size());
+      AnnotationSource<JavaClassSource> annotationSource = classAnnotations.get(0);
+      assertEquals("TestAnnotation", annotationSource.getName());
+      String[] param1 = annotationSource.getStringArrayValue("param1");
+      assertEquals("str1", param1[0]);
+      assertEquals("str2", param1[1]);
+      assertEquals("hello", annotationSource.getStringValue("param2"));
+      assertEquals("{String.class,Main.class}", annotationSource.getLiteralValue("param3"));
+      assertEquals("ENUM_VAL", annotationSource.getLiteralValue("param4"));
+      assertEquals("{ENUM_VAL_1,ENUM_VAL_2,ENUM_VAL_3}", annotationSource.getLiteralValue("param5"));
+
+      assertEquals(0, targetClass.getField("name").getAnnotations().size());
+      assertEquals(0, targetClass.getMethod("getName").getAnnotations().size());
+      assertEquals(0, targetClass.getMethod("setName", "String").getAnnotations().size());
+   }
+
+   @Test
+   public void testAddIncorrectNameAnnotation() throws Exception
+   {
+      createTargetClass(TEST_CLASS_STRING);
+      createCommandController();
+      commandController.initialize();
+
+      String complexAnnotation = "null";
+
+      commandController.setValueFor("annotation", complexAnnotation);
+      try
+      {
+         commandController.execute();
+         fail("IllegalArgumentException should be thrown.");
+      }
+      catch (IllegalArgumentException ex)
+      {
+         assertTrue(ex.getMessage().contains("Annotation with name \"null\" couldn't be added."));
+      }
+   }
+
+   @Test
+   public void testAddMissingParameterValueAnnotation() throws Exception
+   {
+      createTargetClass(TEST_CLASS_STRING);
+      createCommandController();
+      commandController.initialize();
+
+      String complexAnnotation = "Test(param1=)";
+
+      commandController.setValueFor("annotation", complexAnnotation);
+      try
+      {
+         commandController.execute();
+         fail("IllegalArgumentException should be thrown.");
+      }
+      catch (IllegalArgumentException ex)
+      {
+         assertTrue(ex.getMessage().contains("Parameter \"param1\" is missing or is incomplete."));
+      }
+   }
+
+   @Test
+   public void testAddUnparsableAnnotation() throws Exception
+   {
+      createTargetClass(TEST_CLASS_STRING);
+      createCommandController();
+      commandController.initialize();
+
+      String complexAnnotation = "Test.";
+
+      commandController.setValueFor("annotation", complexAnnotation);
+      try
+      {
+         commandController.execute();
+         fail("IllegalArgumentException should be thrown.");
+      }
+      catch (IllegalArgumentException ex)
+      {
+         assertTrue(ex.getMessage().contains("Can't parse annotation"));
+      }
+   }
+
+   private void createTempProject()
+   {
+      project = projectFactory.createTempProject();
+      facetFactory.install(project, JavaSourceFacet.class);
+   }
+
+   private void createTargetClass(String classString) throws FileNotFoundException
+   {
+      targetClass = Roaster.parse(JavaClassSource.class, classString);
+      project.getFacet(JavaSourceFacet.class).saveJavaSource(targetClass);
+   }
+
+   private void createCommandController() throws Exception
+   {
+      commandController = testHarness.createCommandController(JavaAddAnnotationCommand.class,
+               project.getFacet(JavaSourceFacet.class).getJavaResource(targetClass));
+   }
+
+   private void reloadTargetClass() throws FileNotFoundException
+   {
+      targetClass = Roaster.parse(JavaClassSource.class,
+               project.getFacet(JavaSourceFacet.class).getJavaResource(targetClass)
+                        .getUnderlyingResourceObject());
+   }
+
+}


### PR DESCRIPTION
I've just created basic command which adds annotation to the class, field or method. I'm thinking how to do the decomposition of the functionality to use it for example in `ejb-new-bean --named MyService --addNamed` command or to create `cdi-add-qualifier` command

This should be working:

```
java-add-annotation --annotation javax.inject.Named --targetClass org.app.service.MyService
java-add-annotation --annotation javax.inject.Named --targetClass org.app.service.MyService --onProperty myProp
java-add-annotation --annotation javax.inject.Named --targetClass org.app.service.MyService --onMethod myMethod
java-add-annotation --annotation javax.inject.Named --onProperty myProp
java-add-annotation --annotation javax.inject.Named --onMethod myMethod
```
