### PR TITLE
JBIDE-17656 Remove unnecessary System.gc call.

### DIFF
--- a/resources/api/src/main/java/org/jboss/forge/addon/resource/AbstractFileResource.java
+++ b/resources/api/src/main/java/org/jboss/forge/addon/resource/AbstractFileResource.java
@@ -255,10 +255,6 @@ public abstract class AbstractFileResource<T extends FileResource<T>> extends Ab
             Streams.closeQuietly(data);
             out.flush();
             Streams.closeQuietly(out);
-            if (OperatingSystemUtils.isWindows())
-            {
-               System.gc();
-            }
          }
       }
       catch (IOException e)

--- a/resources/api/src/main/java/org/jboss/forge/addon/resource/util/ResourceUtil.java
+++ b/resources/api/src/main/java/org/jboss/forge/addon/resource/util/ResourceUtil.java
@@ -54,10 +54,9 @@ public class ResourceUtil
     */
    public static byte[] getDigest(Resource<?> resource, MessageDigest digest)
    {
-      try (InputStream stream = resource.getResourceInputStream())
+      try (InputStream stream = resource.getResourceInputStream();
+               DigestInputStream digestStream = new DigestInputStream(stream, digest))
       {
-         DigestInputStream digestStream = new DigestInputStream(stream, digest);
-
          byte[] buffer = new byte[16384];
          while (digestStream.read(buffer, 0, buffer.length) != -1)
          {


### PR DESCRIPTION
This ensures that GC is not hinted to the JVM when setting file
contents. It is necessary only when attempting to close file
handles after a deletion.

Also fixed a resource leak issue.
