### PR TITLE
Getting rid of import javax.ws.rs.*

### DIFF
--- a/javaee/impl/src/main/resources/org/jboss/forge/addon/javaee/rest/generator/impl/Endpoint.jv
+++ b/javaee/impl/src/main/resources/org/jboss/forge/addon/javaee/rest/generator/impl/Endpoint.jv
@@ -8,7 +8,6 @@ import javax.persistence.NoResultException;
 import javax.persistence.OptimisticLockException;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
-import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;


### PR DESCRIPTION
Getting rid of import javax.ws.rs._; as it is not needed and Roaster doesn't like to have '_' in imports
