### PR TITLE
Fix NonSnapshotDependencyFilter activation criteria

### DIFF
--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/facets/MavenDependencyFacet.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/facets/MavenDependencyFacet.java
@@ -387,7 +387,7 @@ public class MavenDependencyFacet extends AbstractFacet<Project> implements Depe
    {
       DependencyQueryBuilder query = DependencyQueryBuilder.create(dep.getCoordinate()).setRepositories(
                getRepositories());
-      if (dep.getCoordinate().getVersion() != null && !dep.getCoordinate().getVersion().contains("SNAPSHOT"))
+      if (dep.getCoordinate().getVersion() != null && dep.getCoordinate().getVersion().length() > 0 && !dep.getCoordinate().getVersion().contains("SNAPSHOT"))
       {
          query.setFilter(new NonSnapshotDependencyFilter());
       }


### PR DESCRIPTION
Use case
DependencyBuilder lastOfficialParent = DependencyBuilder.create("myGroupId:myArtifact:::pom"); 
List<Coordinate> foundParentVersions = dependencyFacet.resolveAvailableVersions(lastOfficialParent);

Results 
Only released versions are returned, because NonSnapshotDependencyFilter  activation is checking nullity of version and not empty String