### PR TITLE
first spike of FORGE-2588 lets only create the src/main/java and src/test/java folders if the archetype contains a pom.xml

### DIFF
--- a/maven/impl-projects/pom.xml
+++ b/maven/impl-projects/pom.xml
@@ -7,6 +7,9 @@
    </parent>
    <artifactId>maven-impl-projects</artifactId>
    <name>Forge - Maven Projects Impl</name>
+   <properties>
+      <fabric8.archetypes.version>2.2.95</fabric8.archetypes.version>
+   </properties>
    <dependencies>
       <dependency>
          <groupId>org.jboss.forge.furnace.container</groupId>
@@ -92,6 +95,72 @@
          <classifier>forge-addon</classifier>
          <scope>provided</scope>
       </dependency>
+
+      <!-- testing -->
+      <dependency>
+         <groupId>org.assertj</groupId>
+         <artifactId>assertj-core</artifactId>
+         <version>1.7.1</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.fabric8.archetypes</groupId>
+         <artifactId>golang-example-archetype</artifactId>
+         <version>${fabric8.archetypes.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.fabric8.archetypes</groupId>
+         <artifactId>cdi-camel-archetype</artifactId>
+         <version>${fabric8.archetypes.version}</version>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.10</version>
+            <executions>
+               <execution>
+                  <id>copy</id>
+                  <phase>test-compile</phase>
+                  <goals>
+                     <goal>copy</goal>
+                  </goals>
+                  <configuration>
+                     <artifactItems>
+                        <artifactItem>
+                           <groupId>io.fabric8.archetypes</groupId>
+                           <artifactId>cdi-camel-archetype</artifactId>
+                           <version>${fabric8.archetypes.version}</version>
+                           <type>jar</type>
+                           <overWrite>false</overWrite>
+                           <outputDirectory>${project.build.directory}/test-archetypes</outputDirectory>
+                           <destFileName>cdi-camel-archetype.jar</destFileName>
+                        </artifactItem>
+                        <artifactItem>
+                           <groupId>io.fabric8.archetypes</groupId>
+                           <artifactId>golang-example-archetype</artifactId>
+                           <version>${fabric8.archetypes.version}</version>
+                           <type>jar</type>
+                           <overWrite>false</overWrite>
+                           <outputDirectory>${project.build.directory}/test-archetypes</outputDirectory>
+                           <destFileName>golang-example-archetype.jar</destFileName>
+                        </artifactItem>
+                     </artifactItems>
+                     <!--
+                                            <outputDirectory>${project.build.directory}/wars</outputDirectory>
+                     -->
+                     <overWriteReleases>false</overWriteReleases>
+                     <overWriteSnapshots>true</overWriteSnapshots>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+      </plugins>
+   </build>
 </project>
 

--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ArchetypeHelper.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ArchetypeHelper.java
@@ -239,9 +239,9 @@ public class ArchetypeHelper
       info("Using replace properties: " + replaceProperties);
 
       // now lets replace all the properties in the pom.xml
+      File pom = new File(outputDir, "pom.xml");
       if (!replaceProperties.isEmpty())
       {
-         File pom = new File(outputDir, "pom.xml");
          String text;
          try (FileInputStream fis = new FileInputStream(pom))
          {
@@ -259,7 +259,7 @@ public class ArchetypeHelper
       }
 
       // now lets create the default directories
-      if (createDefaultDirectories)
+      if (createDefaultDirectories && pom.exists())
       {
          File srcDir = new File(outputDir, "src");
          File mainDir = new File(srcDir, "main");

--- a/maven/impl-projects/src/test/java/org/jboss/forge/addon/maven/projects/archetype/ArchetypeHelperClass.java
+++ b/maven/impl-projects/src/test/java/org/jboss/forge/addon/maven/projects/archetype/ArchetypeHelperClass.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.forge.addon.maven.projects.archetype;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ */
+public class ArchetypeHelperClass {
+    protected static final File basedir = new File(System.getProperty("basedir", "."));
+    protected static final File archetypeGenerateDir = new File(basedir, "target/test-archetype-helper");
+    protected static final File archetypeJarDir = new File(basedir, "target/test-archetypes");
+
+    @BeforeClass
+    public static void init() {
+        Files.recursiveDelete(archetypeGenerateDir);
+        archetypeGenerateDir.getParentFile().mkdirs();
+    }
+
+    @Test
+    public void testMavenArchetype() throws Exception {
+        File outputDir = assertCreateArchetype("cdi-camel-archetype.jar");
+
+        assertThat(new File(outputDir, "pom.xml")).exists().isFile();
+        assertThat(new File(outputDir, "src")).exists().isDirectory();
+    }
+
+    @Test
+    public void testNonMavenArchetype() throws Exception {
+        File outputDir = assertCreateArchetype("golang-example-archetype.jar");
+
+        assertThat(new File(outputDir, "pom.xml")).doesNotExist();
+        assertThat(new File(outputDir, "src")).doesNotExist();
+    }
+
+    protected File assertCreateArchetype(String archetypeJarName) throws IOException {
+        String groupId = "com.acme";
+        String artifactId = "myproject";
+        String version = "1.0-SNAPSHOT";
+        File archetypeJar = new File(archetypeJarDir, archetypeJarName);
+        File outputDir = new File(archetypeGenerateDir, archetypeJarName);
+        System.out.println("Executing archetype jar: " + archetypeJar + " in folder: " + outputDir);
+        InputStream archetypeInput = assertOpenFile(archetypeJar);
+        ArchetypeHelper archetypeHelper = new ArchetypeHelper(archetypeInput, outputDir, groupId, artifactId, version);
+        archetypeHelper.setPackageName("com.acme");
+        archetypeHelper.execute();
+        return outputDir;
+    }
+
+    public static InputStream assertOpenFile(File file) throws FileNotFoundException {
+        assertThat(file).isFile().exists();
+        return new FileInputStream(file);
+    }
+
+}

--- a/maven/impl-projects/src/test/java/org/jboss/forge/addon/maven/projects/archetype/Files.java
+++ b/maven/impl-projects/src/test/java/org/jboss/forge/addon/maven/projects/archetype/Files.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.forge.addon.maven.projects.archetype;
+
+import java.io.File;
+
+/**
+ */
+public class Files {
+    /**
+     * Recursively deletes the given file whether its a file or directory returning the number
+     * of files deleted
+     */
+    public static int recursiveDelete(File file) {
+        int answer = 0;
+        if (file.isDirectory()) {
+            File[] files = file.listFiles();
+            if (files != null) {
+                for (File child : files) {
+                    answer += recursiveDelete(child);
+                }
+            }
+        }
+        if (file.delete()) {
+            answer += 1;
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
first spike of FORGE-2588 lets only create the src/main/java and src/test/java folders if the archetype contains a pom.xml