### PR TITLE
fixes FORGE-2590 so that its easy to extend CustomMavenArchetypeProjectType and ConstantArchetypeSelectionWizardStep to add a new ProjectType based on a specific set of maven coordinates for an archetype

### DIFF
--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/CustomMavenArchetypeProjectType.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/CustomMavenArchetypeProjectType.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.forge.addon.maven.projects.archetype;
+
+import org.jboss.forge.addon.ui.wizard.UIWizardStep;
+
+/**
+ * A base class for custom project types defined by an archetype
+ */
+public abstract class CustomMavenArchetypeProjectType extends MavenArchetypeProjectType {
+    private final String type;
+    private final Class<? extends UIWizardStep> flowStep;
+
+    public CustomMavenArchetypeProjectType(Class<? extends UIWizardStep> flowStep, String type) {
+        this.flowStep = flowStep;
+        this.type = type;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public Class<? extends UIWizardStep> getSetupFlow() {
+        return flowStep;
+    }
+
+    @Override
+    public String toString() {
+        return type.toLowerCase().replace(' ', '-');
+    }
+}

--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/CustomMavenArchetypeProjectType.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/CustomMavenArchetypeProjectType.java
@@ -1,6 +1,6 @@
 /**
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
- *
+ * <p/>
  * Licensed under the Eclipse Public License version 1.0, available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
@@ -11,27 +11,32 @@ import org.jboss.forge.addon.ui.wizard.UIWizardStep;
 /**
  * A base class for custom project types defined by an archetype
  */
-public abstract class CustomMavenArchetypeProjectType extends MavenArchetypeProjectType {
-    private final String type;
-    private final Class<? extends UIWizardStep> flowStep;
+public abstract class CustomMavenArchetypeProjectType extends MavenArchetypeProjectType
+{
+   private final String type;
+   private final Class<? extends UIWizardStep> flowStep;
 
-    public CustomMavenArchetypeProjectType(Class<? extends UIWizardStep> flowStep, String type) {
-        this.flowStep = flowStep;
-        this.type = type;
-    }
+   public CustomMavenArchetypeProjectType(Class<? extends UIWizardStep> flowStep, String type)
+   {
+      this.flowStep = flowStep;
+      this.type = type;
+   }
 
-    @Override
-    public String getType() {
-        return type;
-    }
+   @Override
+   public String getType()
+   {
+      return type;
+   }
 
-    @Override
-    public Class<? extends UIWizardStep> getSetupFlow() {
-        return flowStep;
-    }
+   @Override
+   public Class<? extends UIWizardStep> getSetupFlow()
+   {
+      return flowStep;
+   }
 
-    @Override
-    public String toString() {
-        return type.toLowerCase().replace(' ', '-');
-    }
+   @Override
+   public String toString()
+   {
+      return type.toLowerCase().replace(' ', '-');
+   }
 }

--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/CustomMavenArchetypeProjectType.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/CustomMavenArchetypeProjectType.java
@@ -1,18 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.jboss.forge.addon.maven.projects.archetype;
 

--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/AbstractArchetypeSelectionWizardStep.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/AbstractArchetypeSelectionWizardStep.java
@@ -1,6 +1,6 @@
 /**
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
- *
+ * <p/>
  * Licensed under the Eclipse Public License version 1.0, available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
@@ -31,7 +31,8 @@ import java.io.File;
 /**
  * Base class for a wizard step which on execution creates an archetype
  */
-public abstract class ArchetypeSelectionWizardStepSupport extends AbstractUICommand implements UIWizardStep {
+public abstract class AbstractArchetypeSelectionWizardStep extends AbstractUICommand implements UIWizardStep
+{
    @Override
    public NavigationResult next(UINavigationContext context) throws Exception
    {
@@ -51,7 +52,8 @@ public abstract class ArchetypeSelectionWizardStepSupport extends AbstractUIComm
       {
          depQuery.setRepositories(new DependencyRepository("archetype", repository));
       }
-      DependencyResolver resolver = SimpleContainer.getServices(ArchetypeSelectionWizardStepSupport.class.getClassLoader(), DependencyResolver.class)
+      DependencyResolver resolver = SimpleContainer
+               .getServices(AbstractArchetypeSelectionWizardStep.class.getClassLoader(), DependencyResolver.class)
                .get();
       Dependency resolvedArtifact = resolver.resolveArtifact(depQuery);
       FileResource<?> artifact = resolvedArtifact.getArtifact();

--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ArchetypeSelectionWizardStep.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ArchetypeSelectionWizardStep.java
@@ -41,18 +41,11 @@ import org.jboss.forge.furnace.util.Strings;
  * 
  * @author <a href="ggastald@redhat.com">George Gastaldi</a>
  */
-public class ArchetypeSelectionWizardStep extends AbstractUICommand implements UIWizardStep
-{
+public class ArchetypeSelectionWizardStep extends ArchetypeSelectionWizardStepSupport {
    private UIInput<String> archetypeGroupId;
    private UIInput<String> archetypeArtifactId;
    private UIInput<String> archetypeVersion;
    private UIInput<String> archetypeRepository;
-
-   @Override
-   public NavigationResult next(UINavigationContext context) throws Exception
-   {
-      return null;
-   }
 
    @Override
    public UICommandMetadata getMetadata(UIContext context)
@@ -81,7 +74,7 @@ public class ArchetypeSelectionWizardStep extends AbstractUICommand implements U
    @Override
    public void validate(UIValidationContext validator)
    {
-      String repository = archetypeRepository.getValue();
+      String repository = getArchetypeRepository();
       if (!Strings.isNullOrEmpty(repository) && !Strings.isURL(repository))
       {
          validator.addValidationError(archetypeRepository, "Archetype repository must be a valid URL");
@@ -89,29 +82,22 @@ public class ArchetypeSelectionWizardStep extends AbstractUICommand implements U
    }
 
    @Override
-   public Result execute(UIExecutionContext context) throws Exception
-   {
-      UIContext uiContext = context.getUIContext();
-      Project project = (Project) uiContext.getAttributeMap().get(Project.class);
-      String coordinate = archetypeGroupId.getValue() + ":" + archetypeArtifactId.getValue() + ":"
-               + archetypeVersion.getValue();
-      DependencyQueryBuilder depQuery = DependencyQueryBuilder.create(coordinate);
-      String repository = archetypeRepository.getValue();
-      if (repository != null)
-      {
-         depQuery.setRepositories(new DependencyRepository("archetype", repository));
-      }
-      DependencyResolver resolver = SimpleContainer.getServices(getClass().getClassLoader(), DependencyResolver.class)
-               .get();
-      Dependency resolvedArtifact = resolver.resolveArtifact(depQuery);
-      FileResource<?> artifact = resolvedArtifact.getArtifact();
-      MetadataFacet metadataFacet = project.getFacet(MetadataFacet.class);
-      File fileRoot = project.getRoot().reify(DirectoryResource.class).getUnderlyingResourceObject();
-      ArchetypeHelper archetypeHelper = new ArchetypeHelper(artifact.getResourceInputStream(), fileRoot,
-               metadataFacet.getProjectGroupName(), metadataFacet.getProjectName(), metadataFacet.getProjectVersion());
-      JavaSourceFacet facet = project.getFacet(JavaSourceFacet.class);
-      archetypeHelper.setPackageName(facet.getBasePackage());
-      archetypeHelper.execute();
-      return Results.success();
+   protected String getArchetypeRepository() {
+      return archetypeRepository.getValue();
+   }
+
+   @Override
+   protected String getArchetypeVersion() {
+      return archetypeVersion.getValue();
+   }
+
+   @Override
+   protected String getArchetypeArtifactId() {
+      return archetypeArtifactId.getValue();
+   }
+
+   @Override
+   protected String getArchetypeGroupId() {
+      return archetypeGroupId.getValue();
    }
 }

--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ArchetypeSelectionWizardStep.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ArchetypeSelectionWizardStep.java
@@ -1,47 +1,28 @@
 /**
  * Copyright 2014 Red Hat, Inc. and/or its affiliates.
- *
+ * <p/>
  * Licensed under the Eclipse Public License version 1.0, available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
 
 package org.jboss.forge.addon.maven.projects.archetype.ui;
 
-import java.io.File;
-
-import org.jboss.forge.addon.dependencies.Dependency;
-import org.jboss.forge.addon.dependencies.DependencyRepository;
-import org.jboss.forge.addon.dependencies.DependencyResolver;
-import org.jboss.forge.addon.dependencies.builder.DependencyQueryBuilder;
-import org.jboss.forge.addon.maven.projects.archetype.ArchetypeHelper;
-import org.jboss.forge.addon.parser.java.facets.JavaSourceFacet;
-import org.jboss.forge.addon.projects.Project;
-import org.jboss.forge.addon.projects.facets.MetadataFacet;
-import org.jboss.forge.addon.resource.DirectoryResource;
-import org.jboss.forge.addon.resource.FileResource;
-import org.jboss.forge.addon.ui.command.AbstractUICommand;
 import org.jboss.forge.addon.ui.context.UIBuilder;
 import org.jboss.forge.addon.ui.context.UIContext;
-import org.jboss.forge.addon.ui.context.UIExecutionContext;
-import org.jboss.forge.addon.ui.context.UINavigationContext;
 import org.jboss.forge.addon.ui.context.UIValidationContext;
 import org.jboss.forge.addon.ui.input.InputComponentFactory;
 import org.jboss.forge.addon.ui.input.UIInput;
 import org.jboss.forge.addon.ui.metadata.UICommandMetadata;
-import org.jboss.forge.addon.ui.result.NavigationResult;
-import org.jboss.forge.addon.ui.result.Result;
-import org.jboss.forge.addon.ui.result.Results;
 import org.jboss.forge.addon.ui.util.Metadata;
-import org.jboss.forge.addon.ui.wizard.UIWizardStep;
-import org.jboss.forge.furnace.container.simple.lifecycle.SimpleContainer;
 import org.jboss.forge.furnace.util.Strings;
 
 /**
  * Displays a list of archetypes to choose from
- * 
+ *
  * @author <a href="ggastald@redhat.com">George Gastaldi</a>
  */
-public class ArchetypeSelectionWizardStep extends ArchetypeSelectionWizardStepSupport {
+public class ArchetypeSelectionWizardStep extends AbstractArchetypeSelectionWizardStep
+{
    private UIInput<String> archetypeGroupId;
    private UIInput<String> archetypeArtifactId;
    private UIInput<String> archetypeVersion;
@@ -82,22 +63,26 @@ public class ArchetypeSelectionWizardStep extends ArchetypeSelectionWizardStepSu
    }
 
    @Override
-   protected String getArchetypeRepository() {
+   protected String getArchetypeRepository()
+   {
       return archetypeRepository.getValue();
    }
 
    @Override
-   protected String getArchetypeVersion() {
+   protected String getArchetypeVersion()
+   {
       return archetypeVersion.getValue();
    }
 
    @Override
-   protected String getArchetypeArtifactId() {
+   protected String getArchetypeArtifactId()
+   {
       return archetypeArtifactId.getValue();
    }
 
    @Override
-   protected String getArchetypeGroupId() {
+   protected String getArchetypeGroupId()
+   {
       return archetypeGroupId.getValue();
    }
 }

--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ArchetypeSelectionWizardStepSupport.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ArchetypeSelectionWizardStepSupport.java
@@ -1,18 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.jboss.forge.addon.maven.projects.archetype.ui;
 

--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ArchetypeSelectionWizardStepSupport.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ArchetypeSelectionWizardStepSupport.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.forge.addon.maven.projects.archetype.ui;
+
+import org.jboss.forge.addon.dependencies.Dependency;
+import org.jboss.forge.addon.dependencies.DependencyRepository;
+import org.jboss.forge.addon.dependencies.DependencyResolver;
+import org.jboss.forge.addon.dependencies.builder.DependencyQueryBuilder;
+import org.jboss.forge.addon.maven.projects.archetype.ArchetypeHelper;
+import org.jboss.forge.addon.parser.java.facets.JavaSourceFacet;
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.projects.facets.MetadataFacet;
+import org.jboss.forge.addon.resource.DirectoryResource;
+import org.jboss.forge.addon.resource.FileResource;
+import org.jboss.forge.addon.ui.command.AbstractUICommand;
+import org.jboss.forge.addon.ui.context.UIContext;
+import org.jboss.forge.addon.ui.context.UIExecutionContext;
+import org.jboss.forge.addon.ui.context.UINavigationContext;
+import org.jboss.forge.addon.ui.result.NavigationResult;
+import org.jboss.forge.addon.ui.result.Result;
+import org.jboss.forge.addon.ui.result.Results;
+import org.jboss.forge.addon.ui.wizard.UIWizardStep;
+import org.jboss.forge.furnace.container.simple.lifecycle.SimpleContainer;
+
+import java.io.File;
+
+/**
+ * Base class for a wizard step which on execution creates an archetype
+ */
+public abstract class ArchetypeSelectionWizardStepSupport extends AbstractUICommand implements UIWizardStep {
+   @Override
+   public NavigationResult next(UINavigationContext context) throws Exception
+   {
+      return null;
+   }
+
+   @Override
+   public Result execute(UIExecutionContext context) throws Exception
+   {
+      UIContext uiContext = context.getUIContext();
+      Project project = (Project) uiContext.getAttributeMap().get(Project.class);
+      String coordinate = getArchetypeGroupId() + ":" + getArchetypeArtifactId() + ":"
+               + getArchetypeVersion();
+      DependencyQueryBuilder depQuery = DependencyQueryBuilder.create(coordinate);
+      String repository = getArchetypeRepository();
+      if (repository != null)
+      {
+         depQuery.setRepositories(new DependencyRepository("archetype", repository));
+      }
+      DependencyResolver resolver = SimpleContainer.getServices(ArchetypeSelectionWizardStepSupport.class.getClassLoader(), DependencyResolver.class)
+               .get();
+      Dependency resolvedArtifact = resolver.resolveArtifact(depQuery);
+      FileResource<?> artifact = resolvedArtifact.getArtifact();
+      MetadataFacet metadataFacet = project.getFacet(MetadataFacet.class);
+      File fileRoot = project.getRoot().reify(DirectoryResource.class).getUnderlyingResourceObject();
+      ArchetypeHelper archetypeHelper = new ArchetypeHelper(artifact.getResourceInputStream(), fileRoot,
+               metadataFacet.getProjectGroupName(), metadataFacet.getProjectName(), metadataFacet.getProjectVersion());
+      JavaSourceFacet facet = project.getFacet(JavaSourceFacet.class);
+      archetypeHelper.setPackageName(facet.getBasePackage());
+      archetypeHelper.execute();
+      return Results.success();
+   }
+
+   protected abstract String getArchetypeRepository();
+
+   protected abstract String getArchetypeVersion();
+
+   protected abstract String getArchetypeArtifactId();
+
+   protected abstract String getArchetypeGroupId();
+}

--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ConstantArchetypeSelectionWizardStep.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ConstantArchetypeSelectionWizardStep.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.forge.addon.maven.projects.archetype.ui;
+
+/**
+ * Represents a WizardStep that can be used by a ProjectType which resolves to a single constant
+ * archetype using maven coordinates.
+ */
+public abstract class ConstantArchetypeSelectionWizardStep extends ArchetypeSelectionWizardStepSupport {
+    private String archetypeRepository;
+    private String archetypeGroupId;
+    private String archetypeArtifactId;
+    private String archetypeVersion;
+
+    public ConstantArchetypeSelectionWizardStep() {
+    }
+
+    public ConstantArchetypeSelectionWizardStep(String archetypeGroupId, String archetypeArtifactId, String archetypeVersion) {
+        this(archetypeGroupId, archetypeArtifactId, archetypeVersion, null);
+    }
+
+    public ConstantArchetypeSelectionWizardStep(String archetypeGroupId, String archetypeArtifactId, String archetypeVersion, String archetypeRepository) {
+        this.archetypeGroupId = archetypeGroupId;
+        this.archetypeArtifactId = archetypeArtifactId;
+        this.archetypeVersion = archetypeVersion;
+        this.archetypeRepository = archetypeRepository;
+    }
+
+    @Override
+    protected String getArchetypeRepository() {
+        return archetypeRepository;
+    }
+
+    @Override
+    protected String getArchetypeVersion() {
+        return archetypeVersion;
+    }
+
+    @Override
+    protected String getArchetypeArtifactId() {
+        return archetypeArtifactId;
+    }
+
+    @Override
+    protected String getArchetypeGroupId() {
+        return archetypeGroupId;
+    }
+
+    protected void setArchetypeArtifactId(String archetypeArtifactId) {
+        this.archetypeArtifactId = archetypeArtifactId;
+    }
+
+    protected void setArchetypeGroupId(String archetypeGroupId) {
+        this.archetypeGroupId = archetypeGroupId;
+    }
+
+    protected void setArchetypeRepository(String archetypeRepository) {
+        this.archetypeRepository = archetypeRepository;
+    }
+
+    protected void setArchetypeVersion(String archetypeVersion) {
+        this.archetypeVersion = archetypeVersion;
+    }
+}

--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ConstantArchetypeSelectionWizardStep.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ConstantArchetypeSelectionWizardStep.java
@@ -1,6 +1,6 @@
 /**
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
- *
+ * <p/>
  * Licensed under the Eclipse Public License version 1.0, available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
@@ -10,59 +10,73 @@ package org.jboss.forge.addon.maven.projects.archetype.ui;
  * Represents a WizardStep that can be used by a ProjectType which resolves to a single constant
  * archetype using maven coordinates.
  */
-public abstract class ConstantArchetypeSelectionWizardStep extends ArchetypeSelectionWizardStepSupport {
-    private String archetypeRepository;
-    private String archetypeGroupId;
-    private String archetypeArtifactId;
-    private String archetypeVersion;
+public abstract class ConstantArchetypeSelectionWizardStep extends AbstractArchetypeSelectionWizardStep
+{
+   private String archetypeRepository;
+   private String archetypeGroupId;
+   private String archetypeArtifactId;
+   private String archetypeVersion;
 
-    public ConstantArchetypeSelectionWizardStep() {
-    }
+   public ConstantArchetypeSelectionWizardStep()
+   {
+   }
 
-    public ConstantArchetypeSelectionWizardStep(String archetypeGroupId, String archetypeArtifactId, String archetypeVersion) {
-        this(archetypeGroupId, archetypeArtifactId, archetypeVersion, null);
-    }
+   public ConstantArchetypeSelectionWizardStep(String archetypeGroupId, String archetypeArtifactId,
+            String archetypeVersion)
+   {
+      this(archetypeGroupId, archetypeArtifactId, archetypeVersion, null);
+   }
 
-    public ConstantArchetypeSelectionWizardStep(String archetypeGroupId, String archetypeArtifactId, String archetypeVersion, String archetypeRepository) {
-        this.archetypeGroupId = archetypeGroupId;
-        this.archetypeArtifactId = archetypeArtifactId;
-        this.archetypeVersion = archetypeVersion;
-        this.archetypeRepository = archetypeRepository;
-    }
+   public ConstantArchetypeSelectionWizardStep(String archetypeGroupId, String archetypeArtifactId,
+            String archetypeVersion, String archetypeRepository)
+   {
+      this.archetypeGroupId = archetypeGroupId;
+      this.archetypeArtifactId = archetypeArtifactId;
+      this.archetypeVersion = archetypeVersion;
+      this.archetypeRepository = archetypeRepository;
+   }
 
-    @Override
-    protected String getArchetypeRepository() {
-        return archetypeRepository;
-    }
+   @Override
+   protected String getArchetypeRepository()
+   {
+      return archetypeRepository;
+   }
 
-    @Override
-    protected String getArchetypeVersion() {
-        return archetypeVersion;
-    }
+   @Override
+   protected String getArchetypeVersion()
+   {
+      return archetypeVersion;
+   }
 
-    @Override
-    protected String getArchetypeArtifactId() {
-        return archetypeArtifactId;
-    }
+   @Override
+   protected String getArchetypeArtifactId()
+   {
+      return archetypeArtifactId;
+   }
 
-    @Override
-    protected String getArchetypeGroupId() {
-        return archetypeGroupId;
-    }
+   @Override
+   protected String getArchetypeGroupId()
+   {
+      return archetypeGroupId;
+   }
 
-    protected void setArchetypeArtifactId(String archetypeArtifactId) {
-        this.archetypeArtifactId = archetypeArtifactId;
-    }
+   protected void setArchetypeArtifactId(String archetypeArtifactId)
+   {
+      this.archetypeArtifactId = archetypeArtifactId;
+   }
 
-    protected void setArchetypeGroupId(String archetypeGroupId) {
-        this.archetypeGroupId = archetypeGroupId;
-    }
+   protected void setArchetypeGroupId(String archetypeGroupId)
+   {
+      this.archetypeGroupId = archetypeGroupId;
+   }
 
-    protected void setArchetypeRepository(String archetypeRepository) {
-        this.archetypeRepository = archetypeRepository;
-    }
+   protected void setArchetypeRepository(String archetypeRepository)
+   {
+      this.archetypeRepository = archetypeRepository;
+   }
 
-    protected void setArchetypeVersion(String archetypeVersion) {
-        this.archetypeVersion = archetypeVersion;
-    }
+   protected void setArchetypeVersion(String archetypeVersion)
+   {
+      this.archetypeVersion = archetypeVersion;
+   }
 }

--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ConstantArchetypeSelectionWizardStep.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/archetype/ui/ConstantArchetypeSelectionWizardStep.java
@@ -1,18 +1,8 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.jboss.forge.addon.maven.projects.archetype.ui;
 


### PR DESCRIPTION
fixes FORGE-2590 so that its easy to extend CustomMavenArchetypeProjectType and ConstantArchetypeSelectionWizardStep to add a new ProjectType based on a specific set of maven coordinates for an archetype