### PR TITLE
Adds the updated PostgreSQL82Dialect for postrgres

### DIFF
--- a/database-tools/api/src/main/java/org/jboss/forge/addon/database/tools/jpa/HibernateDialect.java
+++ b/database-tools/api/src/main/java/org/jboss/forge/addon/database/tools/jpa/HibernateDialect.java
@@ -18,6 +18,7 @@ public enum HibernateDialect {
 	DB2_AS400("DB2 AS/400", "org.hibernate.dialect.DB2400Dialect"),
 	DB2_OS390("DB2 OS390", "org.hibernate.dialect.DB2390Dialect"),
 	POSTGRESQL("PostgreSQL", "org.hibernate.dialect.PostgreSQLDialect"),
+	POSTGRESQL82("PostgreSQL82","org.hibernate.dialect.PostgreSQL82Dialect"),
 	MICROSOFT_SQL_SERVER_2000("Microsoft SQL Server 2000", "org.hibernate.dialect.SQLServerDialect"),
 	MICROSOFT_SQL_SERVER_2005("Microsoft SQL Server 2005", "org.hibernate.dialect.SQLServer2005Dialect"),
 	MICROSOFT_SQL_SERVER_2008("Microsoft SQL Server 2008", "org.hibernate.dialect.SQLServer2008Dialect"),


### PR DESCRIPTION
The org.hibernate.dialect.PostgreSQLDialect (option 9) is deprecated, this commit adds the newer PostgreSQL82Dialect for postgres.