### PR TITLE
Add missing instructions to the Greeting message 

### DIFF
--- a/bootstrap/src/main/java/org/jboss/forge/bootstrap/listener/GreetingListener.java
+++ b/bootstrap/src/main/java/org/jboss/forge/bootstrap/listener/GreetingListener.java
@@ -40,6 +40,10 @@ public class GreetingListener implements ContainerLifecycleListener
          out.print(Versions.getImplementationVersionFor(getClass()));
          out.print(" ] - JBoss, by Red Hat, Inc. [ http://forge.jboss.org ]");
          out.println();
+         out.println("Hit '<tab>' for a list of available commands.");
+         out.println("and 'man [cmd]' for help on a specific command.");
+         out.println();
+         out.println("To quit the shell, type 'exit'.");
          logger.info(sw.toString());
          System.out.println(sw.toString());
          shellProgressInformation();


### PR DESCRIPTION
- Add missing instructions to the Greeting message displayed within the Forge shell
- How to exit and access doc about the commands