### PR TITLE
FORGE-2762 CDINewBeanCommand - declare dependent scope for CDI 1.1

### DIFF
--- a/javaee/api/src/main/java/org/jboss/forge/addon/javaee/cdi/ui/BeanScope.java
+++ b/javaee/api/src/main/java/org/jboss/forge/addon/javaee/cdi/ui/BeanScope.java
@@ -11,7 +11,7 @@ package org.jboss.forge.addon.javaee.cdi.ui;
  */
 public enum BeanScope
 {
-   DEPENDENT("", false),
+   DEPENDENT("javax.enterprise.context.Dependent", false),
    APPLICATION("javax.enterprise.context.ApplicationScoped", true),
    SESSION("javax.enterprise.context.SessionScoped", true),
    CONVERSATION("javax.enterprise.context.ConversationScoped", true),

--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/cdi/ui/AbstractCDICommand.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/cdi/ui/AbstractCDICommand.java
@@ -74,4 +74,5 @@ public abstract class AbstractCDICommand<T extends JavaSource<?>> extends Abstra
    {
       return projectFactory;
    }
+
 }

--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/cdi/ui/CDINewBeanCommand.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/cdi/ui/CDINewBeanCommand.java
@@ -13,6 +13,7 @@ import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.jboss.forge.addon.javaee.cdi.CDIFacet_1_1;
 import org.jboss.forge.addon.projects.Project;
 import org.jboss.forge.addon.ui.context.UIBuilder;
 import org.jboss.forge.addon.ui.context.UIContext;
@@ -106,6 +107,10 @@ public class CDINewBeanCommand extends AbstractCDICommand<JavaClassSource>
             source.addField().setPrivate().setStatic(true).setFinal(true).setName("serialVersionUID").setType("long")
                      .setLiteralInitializer("1L");
          }
+      }
+      else if (BeanScope.DEPENDENT == scopedValue && project.hasFacet(CDIFacet_1_1.class))
+      {
+         source.addAnnotation(scopedValue.getAnnotation());
       }
       if (withNamed.getValue())
       {

--- a/javaee/tests/src/test/java/org/jboss/forge/addon/javaee/cdi/ui/CDINewBeanCommand_CDI11_Test.java
+++ b/javaee/tests/src/test/java/org/jboss/forge/addon/javaee/cdi/ui/CDINewBeanCommand_CDI11_Test.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.addon.javaee.cdi.ui;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.addon.javaee.ProjectHelper;
+import org.jboss.forge.addon.parser.java.facets.JavaSourceFacet;
+import org.jboss.forge.addon.parser.java.resources.JavaResource;
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.shell.test.ShellTest;
+import org.jboss.forge.addon.ui.controller.CommandController;
+import org.jboss.forge.addon.ui.result.Failed;
+import org.jboss.forge.addon.ui.result.Result;
+import org.jboss.forge.addon.ui.test.UITestHarness;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.forge.roaster.model.JavaClass;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author <a href="ggastald@redhat.com">George Gastaldi</a>
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class CDINewBeanCommand_CDI11_Test
+{
+   @Deployment
+   @AddonDependencies({
+            @AddonDependency(name = "org.jboss.forge.addon:ui-test-harness"),
+            @AddonDependency(name = "org.jboss.forge.addon:shell-test-harness"),
+            @AddonDependency(name = "org.jboss.forge.addon:javaee"),
+            @AddonDependency(name = "org.jboss.forge.addon:maven"),
+            @AddonDependency(name = "org.jboss.forge.furnace.container:cdi")
+   })
+   public static AddonArchive getDeployment()
+   {
+      return ShrinkWrap.create(AddonArchive.class).addBeansXML().addClass(ProjectHelper.class);
+   }
+
+   @Inject
+   private UITestHarness uiTestHarness;
+
+   @Inject
+   private ShellTest shellTest;
+
+   @Inject
+   private ProjectHelper projectHelper;
+
+   private Project project;
+
+   @Before
+   public void setUp()
+   {
+      project = projectHelper.createJavaLibraryProject();
+      projectHelper.installCDI_1_1(project);
+   }
+
+   @After
+   public void tearDown() throws Exception
+   {
+      shellTest.close();
+   }
+
+   @Test
+   public void testCreateNewBean() throws Exception
+   {
+      try (CommandController controller = uiTestHarness.createCommandController(CDINewBeanCommand.class,
+               project.getRoot()))
+      {
+         controller.initialize();
+         controller.setValueFor("named", "MyServiceBean");
+         controller.setValueFor("targetPackage", "org.jboss.forge.test");
+         controller.setValueFor("scoped", BeanScope.DEPENDENT.name());
+         assertTrue(controller.isValid());
+         assertTrue(controller.canExecute());
+         Result result = controller.execute();
+         assertThat(result, is(not(instanceOf(Failed.class))));
+      }
+
+      JavaSourceFacet facet = project.getFacet(JavaSourceFacet.class);
+      JavaResource javaResource = facet.getJavaResource("org.jboss.forge.test.MyServiceBean");
+      assertNotNull(javaResource);
+      assertThat(javaResource.getJavaType(), is(instanceOf(JavaClass.class)));
+      assertTrue(javaResource.getJavaType().hasAnnotation(Dependent.class));
+   }
+
+}


### PR DESCRIPTION
- dependent beans declare scope annotation if CDI 1.1 project facet is
used