### PR TITLE
FORGE-2766: CDIAddObserverMethodCommand improvements.

### DIFF
--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/cdi/ui/AbstractMethodCDICommand.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/cdi/ui/AbstractMethodCDICommand.java
@@ -80,7 +80,7 @@ public abstract class AbstractMethodCDICommand extends AbstractJavaEECommand imp
          try
          {
             javaClass = javaResource.getJavaType();
-            if (javaClass.hasMethodSignature(named.getValue()))
+            if (javaClass.hasMethodSignature(named.getValue(), getParamTypes()))
             {
                validator.addValidationError(named, "Method signature already exists");
             }
@@ -124,8 +124,13 @@ public abstract class AbstractMethodCDICommand extends AbstractJavaEECommand imp
       return true;
    }
 
-   protected Visibility getDefaultVisibility() {
+   protected Visibility getDefaultVisibility()
+   {
       return Visibility.PUBLIC;
+   }
+
+   protected String[] getParamTypes() {
+      return new String[] {};
    }
 
    private void setupAccessType()

--- a/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/cdi/ui/CDIAddProducerMethodCommand.java
+++ b/javaee/impl/src/main/java/org/jboss/forge/addon/javaee/cdi/ui/CDIAddProducerMethodCommand.java
@@ -186,7 +186,13 @@ public class CDIAddProducerMethodCommand extends AbstractMethodCDICommand
    @Override
    protected Visibility getDefaultVisibility()
    {
-      return Visibility.PRIVATE;
+      return Visibility.PACKAGE_PRIVATE;
+   }
+
+   @Override
+   protected String[] getParamTypes()
+   {
+      return injectionPoint.getValue() ? new String[] { InjectionPoint.class.getName() } : super.getParamTypes();
    }
 
    private String getDisposerMethodName()

--- a/javaee/tests/src/test/java/org/jboss/forge/addon/javaee/cdi/ui/CDIAddObserverMethodCommandTest.java
+++ b/javaee/tests/src/test/java/org/jboss/forge/addon/javaee/cdi/ui/CDIAddObserverMethodCommandTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -18,6 +19,8 @@ import java.util.concurrent.TimeUnit;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
+import javax.enterprise.inject.spi.AfterDeploymentValidation;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -97,12 +100,13 @@ public class CDIAddObserverMethodCommandTest
          assertEquals("CDI: Add Observer Method", metadata.getName());
          assertEquals("Java EE", metadata.getCategory().getName());
          assertEquals("CDI", metadata.getCategory().getSubCategory().getName());
-         assertEquals(5, controller.getInputs().size());
+         assertEquals(6, controller.getInputs().size());
          assertTrue(controller.hasInput("named"));
          assertTrue(controller.hasInput("targetClass"));
          assertTrue(controller.hasInput("eventType"));
          assertTrue(controller.hasInput("qualifiers"));
          assertTrue(controller.hasInput("accessType"));
+         assertTrue(controller.hasInput("containerLifecyleEventType"));
       }
    }
 
@@ -158,6 +162,7 @@ public class CDIAddObserverMethodCommandTest
       Method<?, ?> method = myBean.getMethods().get(0);
       Assert.assertEquals("observe", method.getName());
       Assert.assertEquals(1, method.getParameters().size());
+      Assert.assertTrue(method.isPackagePrivate());
       Parameter<?> parameter = method.getParameters().get(0);
       Assert.assertTrue(parameter.hasAnnotation(Observes.class));
       Assert.assertEquals("java.lang.String", parameter.getType().getQualifiedName());
@@ -212,5 +217,84 @@ public class CDIAddObserverMethodCommandTest
       Assert.assertTrue(parameter.hasAnnotation(Observes.class));
       Assert.assertTrue(parameter.hasAnnotation(Default.class));
       Assert.assertTrue(parameter.hasAnnotation(Any.class));
+   }
+
+   @Test
+   public void testCreateNewObserverMethodExtension() throws Exception
+   {
+      try (CommandController controller = uiTestHarness.createCommandController(CDINewExtensionCommand.class,
+               project.getRoot()))
+      {
+         controller.initialize();
+         controller.setValueFor("named", "MyExtension");
+         controller.setValueFor("targetPackage", "org.jboss.forge.test.bean");
+         assertTrue(controller.isValid());
+         assertTrue(controller.canExecute());
+         Result result = controller.execute();
+         Assert.assertThat(result, is(not(instanceOf(Failed.class))));
+      }
+
+      try (CommandController controller = uiTestHarness.createCommandController(CDIAddObserverMethodCommand.class,
+               project.getRoot()))
+      {
+         controller.initialize();
+         controller.setValueFor("named", "pat");
+         controller.setValueFor("targetClass", "org.jboss.forge.test.bean.MyExtension");
+         controller.setValueFor("containerLifecyleEventType", "ProcessAnnotatedType");
+         assertTrue(controller.isValid());
+         assertTrue(controller.canExecute());
+         Result result = controller.execute();
+         Assert.assertThat(result, is(not(instanceOf(Failed.class))));
+      }
+
+      try (CommandController controller = uiTestHarness.createCommandController(CDIAddObserverMethodCommand.class,
+               project.getRoot()))
+      {
+         controller.initialize();
+         controller.setValueFor("named", "adv");
+         controller.setValueFor("targetClass", "org.jboss.forge.test.bean.MyExtension");
+         controller.setValueFor("containerLifecyleEventType", "AfterDeploymentValidation");
+         assertTrue(controller.isValid());
+         assertTrue(controller.canExecute());
+         Result result = controller.execute();
+         Assert.assertThat(result, is(not(instanceOf(Failed.class))));
+      }
+
+      // Test duplicate method
+      try (CommandController controller = uiTestHarness.createCommandController(CDIAddObserverMethodCommand.class,
+               project.getRoot()))
+      {
+         controller.initialize();
+         controller.setValueFor("named", "adv");
+         controller.setValueFor("targetClass", "org.jboss.forge.test.bean.MyExtension");
+         controller.setValueFor("containerLifecyleEventType", "AfterDeploymentValidation");
+         assertFalse(controller.isValid());
+      }
+
+      JavaSourceFacet facet = project.getFacet(JavaSourceFacet.class);
+      JavaResource javaResource = facet.getJavaResource("org.jboss.forge.test.bean.MyExtension");
+      Assert.assertNotNull(javaResource);
+      Assert.assertThat(javaResource.getJavaType(), is(instanceOf(JavaClass.class)));
+      JavaClass<?> myExtension = javaResource.getJavaType();
+      Assert.assertEquals(2, myExtension.getMethods().size());
+      Assert.assertEquals(1, myExtension.getInterfaces().size());
+
+      Method<?, ?> pat = myExtension.getMethod("pat", ProcessAnnotatedType.class);
+      Assert.assertNotNull(pat);
+      Assert.assertEquals(1, pat.getParameters().size());
+      Assert.assertTrue(pat.isPackagePrivate());
+      Parameter<?> patParam = pat.getParameters().get(0);
+      Assert.assertTrue(patParam.hasAnnotation(Observes.class));
+      Assert.assertEquals("javax.enterprise.inject.spi.ProcessAnnotatedType<?>", patParam.getType().getQualifiedNameWithGenerics());
+      Assert.assertEquals("event", patParam.getName());
+
+      Method<?, ?> adv = myExtension.getMethod("adv", AfterDeploymentValidation.class);
+      Assert.assertNotNull(adv);
+      Assert.assertEquals(1, adv.getParameters().size());
+      Assert.assertTrue(adv.isPackagePrivate());
+      Parameter<?> advParam = adv.getParameters().get(0);
+      Assert.assertTrue(advParam.hasAnnotation(Observes.class));
+      Assert.assertEquals("javax.enterprise.inject.spi.AfterDeploymentValidation", advParam.getType().getQualifiedName());
+      Assert.assertEquals("event", advParam.getName());
    }
 }

--- a/ui/api/src/main/java/org/jboss/forge/addon/ui/util/InputComponents.java
+++ b/ui/api/src/main/java/org/jboss/forge/addon/ui/util/InputComponents.java
@@ -28,9 +28,9 @@ import org.jboss.forge.furnace.util.Strings;
 
 /**
  * Utilities for {@link InputComponent} objects
- * 
+ *
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
- * 
+ *
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public final class InputComponents
@@ -72,7 +72,7 @@ public final class InputComponents
 
    /**
     * Sets the value in the provided {@link InputComponent}, making any necessary conversions
-    * 
+    *
     * @param component
     * @param value
     */
@@ -91,7 +91,7 @@ public final class InputComponents
 
    /**
     * Sets the default value in the provided {@link InputComponent}, making any necessary conversions
-    * 
+    *
     * @param component
     * @param value
     */
@@ -317,15 +317,15 @@ public final class InputComponents
    }
 
    /**
-    * Validate if the input has a value. If not, return the error message
-    * 
+    * Validate if an required and enabled input has a value. If not, return the error message.
+    *
     * @param input
     * @return
     */
    public static String validateRequired(final InputComponent<?, ?> input)
    {
       String requiredMessage = null;
-      if (input.isRequired() && !InputComponents.hasValue(input))
+      if (input.isEnabled() && input.isRequired() && !InputComponents.hasValue(input))
       {
          requiredMessage = input.getRequiredMessage();
          if (Strings.isNullOrEmpty(requiredMessage))
@@ -343,9 +343,9 @@ public final class InputComponents
    }
 
    /**
-    * 
+    *
     * Returns the item label converter, that is
-    * 
+    *
     * @param converterFactory May be null
     * @param input
     * @return the item label converter of a {@link SelectComponent} or a {@link Converter} instance from the
@@ -365,7 +365,7 @@ public final class InputComponents
 
    /**
     * Returns the label for this component
-    * 
+    *
     * @param input the input component
     * @param addColon should a colon be added in the end of the label ?
     * @return the label with a colon in the end if addColon is true
@@ -388,7 +388,7 @@ public final class InputComponents
 
    /**
     * Returns the completer associated with this {@link InputComponent} or null if it is not available
-    * 
+    *
     * @param inputComponent
     * @return the {@link UICompleter} associated with this {@link InputComponent} or null if not available or the
     *         {@link InputComponent} does not implement {@link HasCompleter}
@@ -409,14 +409,14 @@ public final class InputComponents
 
    /**
     * Determines whether two possibly-null objects are equal. Returns:
-    * 
+    *
     * <ul>
     * <li>{@code true} if {@code a} and {@code b} are both null.
     * <li>{@code true} if {@code a} and {@code b} are both non-null and they are equal according to
     * {@link Object#equals(Object)}.
     * <li>{@code false} in all other situations.
     * </ul>
-    * 
+    *
     * <p>
     * This assumes that any non-null objects passed to this function conform to the {@code equals()} contract.
     */


### PR DESCRIPTION
- list container lifecycle event types if the target class is a portable extension
- also skip validation of disabled required inputs
- fix validation of duplicate methods
- change the default visibility for producers and observers to package-private