### PR TITLE
FORGE-2784: bin/forge java version check fix

### DIFF
--- a/dist/src/main/resources/bin/forge
+++ b/dist/src/main/resources/bin/forge
@@ -148,12 +148,26 @@ if [ ! -x "$JAVACMD" ] ; then
   exit 1
 fi
 
-JAVAVER=`"$JAVACMD" -version 2>&1`
+# Get java version from the release file, if it exists,
+# to by pass "java -version" execution time.
+if [ -r "$JAVA_HOME/release" ] ; then
+  while read line
+  do
+    case $line in JAVA_VERSION=*)
+      JAVAVER=$line
+      break
+    esac
+  done <"$JAVA_HOME/release"
+fi
+
+JAVAVER=${JAVAVER-`"$JAVACMD" -version 2>&1`}
+JAVAVER="${JAVAVER#*\"}" # Strip everything up to the first "
+JAVAVER="${JAVAVER%%\"*}"; # Strip everything after the first "
+
 case $JAVAVER in
-*1.[7-9]*) ;;
-*1.[1-6]*)
-	echo " Error: a Java 1.7 or higher JRE is required to run Forge; found [$JAVACMD -version == $JAVAVER]."
-	exit 1
+1.[1-6]*)
+  echo " Error: a Java 1.7 or higher JRE is required to run Forge. $JAVACMD is version $JAVAVER"
+  exit 1
  ;;
 esac
 


### PR DESCRIPTION
bin/forge shell script java version validation now matches for
"1.[1-6]*" instead of "*1.[1-6]*". Which could fail for some
future java versions (e.g. 10.1.1). It also does a preliminary
check for the JAVA_VERSION in the %JAVA_HOME%\release text
file (if it exists) to avoid time spent running "java -version".