### PR TITLE
FORGE-2792: Update Maven command for Windows

### DIFF
--- a/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/MavenFacetImpl.java
+++ b/maven/impl-projects/src/main/java/org/jboss/forge/addon/maven/projects/MavenFacetImpl.java
@@ -424,7 +424,7 @@ public class MavenFacetImpl extends AbstractFacet<Project> implements ProjectFac
 
    private String getMvnCommand()
    {
-      return OperatingSystemUtils.isWindows() ? "mvn.bat" : "mvn";
+      return OperatingSystemUtils.isWindows() ? "mvn.cmd" : "mvn";
    }
 
    @Override


### PR DESCRIPTION
Changed Maven command for Windows environments, this should make Forge compatible with Maven versions >= 3.3.0