### PR TITLE
FORGE-2793: Add custom proxy exceptions support

### DIFF
--- a/configuration/impl/src/main/java/org/jboss/forge/addon/configuration/proxy/ForgeProxySelector.java
+++ b/configuration/impl/src/main/java/org/jboss/forge/addon/configuration/proxy/ForgeProxySelector.java
@@ -41,8 +41,8 @@ public class ForgeProxySelector extends ProxySelector
       {
          throw new IllegalArgumentException("URI can't be null.");
       }
-      String protocol = uri.getScheme();
-      if ("http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol))
+
+      if (proxySettings != null && isProxyAvailable(uri))
       {
          ArrayList<Proxy> result = new ArrayList<Proxy>();
          result.add(new Proxy(Type.HTTP, new InetSocketAddress(proxySettings.getProxyHost(),
@@ -71,6 +71,20 @@ public class ForgeProxySelector extends ProxySelector
          result.add(Proxy.NO_PROXY);
          return result;
       }
+   }
+
+   private boolean isProxyAvailable(final URI uri)
+   {
+      final String host = uri.getHost();
+      final String protocol = uri.getScheme();
+
+      boolean isValidProtocol =
+               "http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol);
+
+      boolean isHostExcluded =
+               proxySettings.getNonProxyHosts() != null
+                        && proxySettings.getNonProxyHosts().contains(host);
+      return isValidProtocol && !isHostExcluded;
    }
 
    @Override

--- a/configuration/impl/src/main/java/org/jboss/forge/addon/configuration/proxy/ProxySettings.java
+++ b/configuration/impl/src/main/java/org/jboss/forge/addon/configuration/proxy/ProxySettings.java
@@ -1,11 +1,12 @@
 /**
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Eclipse Public License version 1.0, available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Licensed under the Eclipse Public License version 1.0, available at http://www.eclipse.org/legal/epl-v10.html
  */
 package org.jboss.forge.addon.configuration.proxy;
 
+import java.util.Arrays;
+import java.util.List;
 import org.jboss.forge.addon.configuration.Configuration;
 
 public class ProxySettings
@@ -15,29 +16,38 @@ public class ProxySettings
    private static final String PROXY_CONFIG_PORT_KEY = "port";
    private static final String PROXY_CONFIG_USERNAME_KEY = "username";
    private static final String PROXY_CONFIG_PASSWORD_KEY = "password";
+   private static final String PROXY_CONFIG_NON_PROXY_HOSTS = "nonProxyHosts";
 
    private final String proxyHost;
    private final int proxyPort;
    private final String proxyUserName;
    private final String proxyPassword;
+   private final List<String> nonProxyHosts;
 
-   private ProxySettings(String proxyHost, int proxyPort, String proxyUserName, String proxyPassword)
+   private ProxySettings(String proxyHost, int proxyPort, String proxyUserName, String proxyPassword,
+            List<String> nonProxyHosts)
    {
       this.proxyHost = proxyHost;
       this.proxyPort = proxyPort;
       this.proxyUserName = proxyUserName;
       this.proxyPassword = proxyPassword;
+      this.nonProxyHosts = nonProxyHosts;
    }
 
    public static ProxySettings fromHostAndPort(String proxyHost, int proxyPort)
    {
-      return new ProxySettings(proxyHost, proxyPort, null, null);
+      return new ProxySettings(proxyHost, proxyPort, null, null, null);
+   }
+
+   public static ProxySettings fromHostPortAndNonProxyHosts(String proxyHost, int proxyPort, List<String> nonProxyHosts)
+   {
+      return new ProxySettings(proxyHost, proxyPort, null, null, nonProxyHosts);
    }
 
    public static ProxySettings fromHostPortAndCredentials(String proxyHost, int proxyPort,
             String proxyUserName, String proxyPassword)
    {
-      return new ProxySettings(proxyHost, proxyPort, proxyUserName, proxyPassword);
+      return new ProxySettings(proxyHost, proxyPort, proxyUserName, proxyPassword, null);
    }
 
    public static ProxySettings fromForgeConfiguration(Configuration configuration)
@@ -46,9 +56,20 @@ public class ProxySettings
       Configuration proxyConfig = configuration.subset("proxy");
       if (proxyConfig != null && !proxyConfig.isEmpty())
       {
-         return new ProxySettings(proxyConfig.getString(PROXY_CONFIG_HOST_KEY),
-                  proxyConfig.getInt(PROXY_CONFIG_PORT_KEY), proxyConfig.getString(PROXY_CONFIG_USERNAME_KEY),
-                  proxyConfig.getString(PROXY_CONFIG_PASSWORD_KEY));
+         final String nonProxyHosts = proxyConfig.getString(PROXY_CONFIG_NON_PROXY_HOSTS);
+         List<String> nonProxyHostsList = null;
+         if (nonProxyHosts != null)
+         {
+            nonProxyHostsList = Arrays.asList(nonProxyHosts.split(","));
+         }
+
+         return new ProxySettings(
+                  proxyConfig.getString(PROXY_CONFIG_HOST_KEY),
+                  proxyConfig.getInt(PROXY_CONFIG_PORT_KEY),
+                  proxyConfig.getString(PROXY_CONFIG_USERNAME_KEY),
+                  proxyConfig.getString(PROXY_CONFIG_PASSWORD_KEY),
+                  nonProxyHostsList
+         );
       }
       else
       {
@@ -74,6 +95,11 @@ public class ProxySettings
    public String getProxyPassword()
    {
       return proxyPassword;
+   }
+
+   public List<String> getNonProxyHosts()
+   {
+      return nonProxyHosts;
    }
 
    public boolean isAuthenticationSupported()

--- a/configuration/tests/src/test/java/org/jboss/forge/addon/configuration/proxy/ForgeProxySelectorTest.java
+++ b/configuration/tests/src/test/java/org/jboss/forge/addon/configuration/proxy/ForgeProxySelectorTest.java
@@ -1,0 +1,69 @@
+package org.jboss.forge.addon.configuration.proxy;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.Proxy;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.configuration.BaseConfiguration;
+import org.jboss.forge.addon.configuration.Configuration;
+import org.jboss.forge.addon.configuration.ConfigurationAdapter;
+import org.junit.Test;
+
+public class ForgeProxySelectorTest
+{
+   private static final String PROXY_HOST = "test.proxy.org";
+   private static final int PROXY_PORT = 8080;
+
+   @Test
+   public void testNoProxy() throws URISyntaxException
+   {
+      final Configuration configuration = new ConfigurationAdapter(new BaseConfiguration());
+      final ProxySettings proxySettings = ProxySettings.fromForgeConfiguration(configuration);
+      final ForgeProxySelector forgeProxySelector = new ForgeProxySelector(null, proxySettings);
+
+      final URI testURI = new URI("https://host.org/resource.html");
+      final List<Proxy> expectedProxies = forgeProxySelector.select(testURI);
+
+
+      assertEquals(1, expectedProxies.size());
+      assertEquals(Proxy.NO_PROXY, expectedProxies.get(0));
+   }
+
+   @Test
+   public void testProxy() throws URISyntaxException
+   {
+      final ProxySettings proxySettings = ProxySettings.fromHostAndPort(PROXY_HOST, PROXY_PORT);
+      final ForgeProxySelector forgeProxySelector = new ForgeProxySelector(null, proxySettings);
+
+      final URI testURI = new URI("https://host.org/resource.html");
+      final List<Proxy> expectedProxies = forgeProxySelector.select(testURI);
+
+
+      assertEquals(1, expectedProxies.size());
+      assertEquals(PROXY_HOST + ":" + PROXY_PORT, expectedProxies.get(0).address().toString());
+   }
+
+   @Test
+   public void testProxyWithExclusion() throws URISyntaxException
+   {
+      final List<String> nonProxyHosts = Collections.singletonList("non.proxied.org");
+      final ProxySettings proxySettings =
+               ProxySettings.fromHostPortAndNonProxyHosts(PROXY_HOST, PROXY_PORT, nonProxyHosts);
+      final ForgeProxySelector forgeProxySelector = new ForgeProxySelector(null, proxySettings);
+
+      final URI testProxiedURI = new URI("https://host.org/resource.html");
+      final List<Proxy> expectedProxies = forgeProxySelector.select(testProxiedURI);
+
+      assertEquals(1, expectedProxies.size());
+      assertEquals(PROXY_HOST + ":" + PROXY_PORT, expectedProxies.get(0).address().toString());
+
+      final URI testNonProxiedURI = new URI("https://non.proxied.org/other-resource.html");
+      final List<Proxy> expectedNoProxies = forgeProxySelector.select(testNonProxiedURI);
+
+      assertEquals(1, expectedNoProxies.size());
+      assertEquals(Proxy.NO_PROXY, expectedNoProxies.get(0));
+   }
+}


### PR DESCRIPTION
Following [this documentation](https://docs.oracle.com/javase/6/docs/technotes/guides/net/proxies.html), I added the `nonProxyHosts` parameter support in configuration.