### PR TITLE
FORGE-2795: Bump javaee-spi to Java EE 8.0.1

### DIFF
--- a/javaee/spi/pom.xml
+++ b/javaee/spi/pom.xml
@@ -12,12 +12,12 @@
       <dependency>
          <groupId>javax</groupId>
          <artifactId>javaee-api</artifactId>
-         <version>7.0</version>
+         <version>8.0.1</version>
       </dependency>
       <dependency>
          <groupId>org.glassfish</groupId>
          <artifactId>javax.json</artifactId>
-         <version>1.0.4</version>
+         <version>1.1.4</version>
       </dependency>
    </dependencies>
    <build>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/FORGE-2795