### PR TITLE
Include add-opens for JDK 17+

### DIFF
--- a/dist/src/main/resources/bin/forge
+++ b/dist/src/main/resources/bin/forge
@@ -193,7 +193,7 @@ if [ -r "$FORGE_HOME/addons/" ] ; then
   ADDONS_DIR="--immutableAddonDir \"$FORGE_HOME/addons/\""
 fi
 
-forge_exec_cmd="\"$JAVACMD\" $FORGE_DEBUG_ARGS $FORGE_OPTS \"-Dforge.standalone=true\" \"-Dforge.home=${FORGE_HOME}\" \
+forge_exec_cmd="\"$JAVACMD\" $FORGE_DEBUG_ARGS $FORGE_OPTS \"--add-opens=java.base/java.lang=ALL-UNNAMED\" \"--add-opens=java.base/java.util=ALL-UNNAMED\"  \"-Dforge.standalone=true\" \"-Dforge.home=${FORGE_HOME}\" \
    -cp \"${FORGE_HOME}/lib/*\" $FORGE_MAIN_CLASS"
 
 eval $forge_exec_cmd "$QUOTED_ARGS" "$ADDONS_DIR"


### PR DESCRIPTION
Forge requires this to work in JDK 17+